### PR TITLE
Fixed bug with MAP calculation

### DIFF
--- a/rectools/metrics/ranking.py
+++ b/rectools/metrics/ranking.py
@@ -208,9 +208,10 @@ class MAP(_RankingMetric):
         # Here rows - users, columns - all possible k
         full_cumsum = np.cumsum(csr.data)
         n_row_elements = np.diff(csr.indptr)
+        row_sums = np.asarray(csr.sum(axis=1)).ravel()
         sum_n_elements_in_prev_rows = np.repeat(
             # add [0] because no elements before first row
-            np.concatenate((np.array([0]), np.cumsum(n_row_elements)[:-1])),
+            np.concatenate((np.array([0]), np.cumsum(row_sums)[:-1])),
             n_row_elements,
         )
 

--- a/tests/metrics/test_ranking.py
+++ b/tests/metrics/test_ranking.py
@@ -67,6 +67,28 @@ class TestMAP:
         pd.testing.assert_series_equal(metric.calc_per_user(reco, EMPTY_INTERACTIONS), expected_metric_per_user)
         assert np.isnan(metric.calc(reco, EMPTY_INTERACTIONS))
 
+    def test_when_duplicates_in_interactions(self) -> None:
+        reco = pd.DataFrame(
+            {
+                Columns.User: [1, 1, 1, 2, 2, 2],
+                Columns.Item: [1, 2, 3, 1, 2, 3],
+                Columns.Rank: [1, 2, 3, 1, 2, 3],
+            }
+        )
+        interactions = pd.DataFrame(
+            {
+                Columns.User: [1, 1, 1, 2, 2, 2],
+                Columns.Item: [1, 2, 1, 1, 2, 3],
+            }
+        )
+        metric = MAP(k=3)
+        expected_metric_per_user = pd.Series(
+            [3.5 / 3, 3 / 3],
+            index=pd.Series([1, 2], name=Columns.User),
+            dtype=float,
+        )
+        pd.testing.assert_series_equal(metric.calc_per_user(reco, interactions), expected_metric_per_user)
+
 
 class TestNDCG:
 


### PR DESCRIPTION
There was a bug with calculating MAP metric in case when some duplicated interactions present in the test data. This Pull request fixes it.