### PR TITLE
Metrics. Roc-curve plot and auc added

### DIFF
--- a/rectools/metrics/__init__.py
+++ b/rectools/metrics/__init__.py
@@ -52,6 +52,7 @@ from .novelty import MeanInvUserFreq
 from .ranking import MAP, MRR, NDCG
 from .scoring import calc_metrics
 from .serendipity import Serendipity
+from .roc_auc import AUC
 
 __all__ = (
     "Precision",
@@ -62,6 +63,7 @@ __all__ = (
     "MAP",
     "NDCG",
     "MRR",
+    "AUC",
     "MeanInvUserFreq",
     "IntraListDiversity",
     "Serendipity",

--- a/rectools/metrics/roc_auc.py
+++ b/rectools/metrics/roc_auc.py
@@ -1,0 +1,98 @@
+import attr
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+from rectools import ExternalId, ExternalIds, Columns
+from .base import MetricAtK, Catalog
+from .classification import make_confusions
+
+
+TP = "__TP"
+FP = "__FP"
+FN = "__FN"
+TN = "__TN"
+LIKED = "__LIKED"
+
+
+@attr.s
+class AUC(MetricAtK):
+
+    def plot_roc_for_user(self, user_id: ExternalId, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog):
+        self._auc_check(reco, interactions, user_id, catalog)
+        user_reco = reco.loc[reco[Columns.User] == user_id]
+        user_interactions = interactions.loc[interactions[Columns.User] == user_id]
+        if user_interactions.empty:
+            raise ValueError(f"user {user_id} has no interactions. Can't build roc-curve")
+        tpr = np.zeros(self.k + 1)
+        fpr = np.zeros(self.k + 1)
+        tpr[self.k] = 1.0
+        fpr[self.k] = 1.0
+
+        for roc_k in range(self.k):
+            confusion_df = self.make_extended_confusions(user_reco, user_interactions, roc_k, catalog)
+            tpr[roc_k] = confusion_df[TP] / (confusion_df[TP] + confusion_df[FN])
+            fpr[roc_k] = confusion_df[FP] / (confusion_df[FP] + confusion_df[TN])
+
+        plt.figure(figsize=(8, 8))
+        plt.plot(fpr, tpr, c='orange')
+        plt.plot([0.0, 1.0], [0.0, 1.0], linestyle='dashed', c='green')
+        plt.title('ROC curve')
+        plt.xlabel('FPR')
+        plt.ylabel('TPR')
+        plt.xlim((-0.01, 1.01))
+        plt.ylim((-0.01, 1.01))
+        plt.show()
+
+
+    @staticmethod
+    def make_extended_confusions(reco: pd.DataFrame, interactions: pd.DataFrame, k: int, catalog: Catalog):
+        confusion_df = make_confusions(reco, interactions, k)
+        if TN not in confusion_df:
+            confusion_df[TN] = len(catalog) - k - confusion_df[FN]
+        return confusion_df
+
+    def _auc_check(self, reco: pd.DataFrame, interactions: pd.DataFrame, user_id: ExternalId, catalog: Catalog):
+        MetricAtK._check(reco, interactions=interactions)
+        if user_id not in reco[Columns.User]:
+            raise ValueError(f"Expected user_id from recommendations, got {user_id}")
+
+    def calc(self, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog) -> float:
+        per_user = self.calc_per_user(reco, interactions, catalog)
+        return per_user.mean()
+
+    def calc_per_user(self, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog) -> pd.Series:
+        MetricAtK._check(reco, interactions=interactions)
+        users = np.array(reco[Columns.User].unique())
+        per_user = np.zeros_like(users, dtype=float)
+        for index, user_id in enumerate(reco[Columns.User].unique()):
+            per_user[index] = self.calc_for_user(user_id, reco, interactions, catalog)
+
+        return pd.Series(data=per_user, index=users)
+
+    def calc_for_user(self, user_id: ExternalId, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog) -> float:
+        user_reco = reco.loc[reco[Columns.User] == user_id]
+        user_interactions = interactions.loc[interactions[Columns.User] == user_id]
+        if user_interactions.empty:
+            return np.nan
+        positives = user_interactions[Columns.Item]
+        negatives = list(set(catalog) - set(positives))
+        auc_numerator = 0
+        for positive_item in positives:
+            for negative_item in negatives:
+                auc_numerator += self._auc_positive_scored_higher(positive_item, negative_item, user_reco)
+
+        return auc_numerator / (len(positives) * len(negatives))
+
+    @staticmethod
+    def _auc_positive_scored_higher(positive_item: ExternalId, negative_item: ExternalId, user_reco: pd.DataFrame):
+        pos_score = float(user_reco.loc[user_reco[Columns.Item] == positive_item][Columns.Score]) if not user_reco.loc[user_reco[Columns.Item] == positive_item].empty else 0.0
+        neg_score = float(user_reco.loc[user_reco[Columns.Item] == negative_item][Columns.Score]) if not user_reco.loc[
+            user_reco[Columns.Item] == negative_item].empty else 0.0
+        if pos_score > neg_score:
+            return 1.0
+        if pos_score == neg_score:
+            return 0.5
+        return 0.0
+

--- a/rectools/metrics/roc_auc.py
+++ b/rectools/metrics/roc_auc.py
@@ -1,13 +1,13 @@
+import typing as tp
+
 import attr
-import pandas as pd
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 
+from rectools import Columns, ExternalId
 
-from rectools import ExternalId, ExternalIds, Columns
-from .base import MetricAtK, Catalog
-from .classification import make_confusions
-
+from .base import Catalog, MetricAtK
 
 TP = "__TP"
 FP = "__FP"
@@ -18,51 +18,106 @@ LIKED = "__LIKED"
 
 @attr.s
 class AUC(MetricAtK):
+    """
+    ROC-curve is a graph showing the performance of a classification model at all classification thresholds
+    AUC is an area under the roc-curve
+    See more: https://en.wikipedia.org/wiki/Receiver_operating_characteristic
+        and: https://wiki.epfl.ch/edicpublic/documents/Candidacy%20exam/Evaluation.pdf
 
-    def plot_roc_for_user(self, user_id: ExternalId, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog):
+    Parameters
+    ----------
+    k : int
+        Number of items in top of recommendations list that will be used to calculate metric.
+    """
+
+    def plot_roc_for_user(
+        self, user_id: ExternalId, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog
+    ) -> None:
+        """
+        ROC-curve is a graph showing the performance of a classification model at all classification thresholds
+        This method plot roc-curve for thresholds from 0 to k recommended items with linear continuation to (1, 1)
+        See more: https://wiki.epfl.ch/edicpublic/documents/Candidacy%20exam/Evaluation.pdf
+
+        y-axis: ``tpr`` equals to ``tp / (tp + fn)``
+        x-axis: ``fpr`` equals to ``fp / (fp + tn)``
+        where
+        - ``tp`` is the number of relevant recommendations
+          among the first ``k`` items in recommendation list;
+        - ``tn`` is the number of items with which user has not interacted (bought, liked) with
+          (in period after recommendations were given) and we do not recommend to him
+          (in the top ``k`` items of recommendation list);
+        - ``fp`` - number of non-relevant recommendations among the first `k` items of recommendation list;
+        - ``fn`` - number of items the user has interacted with but that weren't recommended (in top-`k`)
+
+        """
         self._auc_check(reco, interactions, user_id, catalog)
         user_reco = reco.loc[reco[Columns.User] == user_id]
         user_interactions = interactions.loc[interactions[Columns.User] == user_id]
         if user_interactions.empty:
             raise ValueError(f"user {user_id} has no interactions. Can't build roc-curve")
-        tpr = np.zeros(self.k + 1)
-        fpr = np.zeros(self.k + 1)
-        tpr[self.k] = 1.0
-        fpr[self.k] = 1.0
 
-        for roc_k in range(self.k):
-            confusion_df = self.make_extended_confusions(user_reco, user_interactions, roc_k, catalog)
-            tpr[roc_k] = confusion_df[TP] / (confusion_df[TP] + confusion_df[FN])
-            fpr[roc_k] = confusion_df[FP] / (confusion_df[FP] + confusion_df[TN])
+        tpr, fpr = self._calc_tpr_fpr(user_reco, user_interactions, catalog)
 
         plt.figure(figsize=(8, 8))
-        plt.plot(fpr, tpr, c='orange')
-        plt.plot([0.0, 1.0], [0.0, 1.0], linestyle='dashed', c='green')
-        plt.title('ROC curve')
-        plt.xlabel('FPR')
-        plt.ylabel('TPR')
+        plt.plot(fpr, tpr, c="orange")
+        plt.plot([0.0, 1.0], [0.0, 1.0], linestyle="dashed", c="green")
+        plt.title("ROC curve")
+        plt.xlabel("FPR")
+        plt.ylabel("TPR")
         plt.xlim((-0.01, 1.01))
         plt.ylim((-0.01, 1.01))
         plt.show()
 
+    def _calc_tpr_fpr(
+        self, user_reco: pd.DataFrame, user_interactions: pd.DataFrame, catalog: Catalog
+    ) -> tp.Tuple[np.array, np.array]:
+        """
+        Calculate tpr and fpr for roc-curve
+        make_confusions is not used for optimization. Data is updating instead of recalculating
+
+        """
+        tpr = np.zeros(self.k + 2)
+        fpr = np.zeros(self.k + 2)
+        tpr[self.k + 1] = 1.0
+        fpr[self.k + 1] = 1.0
+
+        _tp = 0
+        _fp = 0
+        _fn = len(user_interactions[Columns.Item].unique())
+        _tn = len(catalog) - _fn
+        for roc_k in range(self.k):
+            if not user_interactions.loc[user_interactions[Columns.Item] == user_reco.iloc[roc_k][Columns.Item]].empty:
+                _tp += 1
+                _fn -= 1
+            else:
+                _fp += 1
+                _tn -= 1
+            tpr[roc_k + 1] = _tp / (_tp + _fn)
+            fpr[roc_k + 1] = _fp / (_fp + _tn)
+        return tpr, fpr
 
     @staticmethod
-    def make_extended_confusions(reco: pd.DataFrame, interactions: pd.DataFrame, k: int, catalog: Catalog):
-        confusion_df = make_confusions(reco, interactions, k)
-        if TN not in confusion_df:
-            confusion_df[TN] = len(catalog) - k - confusion_df[FN]
-        return confusion_df
-
-    def _auc_check(self, reco: pd.DataFrame, interactions: pd.DataFrame, user_id: ExternalId, catalog: Catalog):
+    def _auc_check(self, reco: pd.DataFrame, interactions: pd.DataFrame, user_id: ExternalId, catalog: Catalog) -> None:
         MetricAtK._check(reco, interactions=interactions)
         if user_id not in reco[Columns.User]:
             raise ValueError(f"Expected user_id from recommendations, got {user_id}")
 
     def calc(self, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog) -> float:
+        """
+        AUC is an area under the roc-curve.
+        This method calculates auc for all users
+        Note that for users without interactions calc_for_user is NaN
+
+        """
         per_user = self.calc_per_user(reco, interactions, catalog)
         return per_user.mean()
 
     def calc_per_user(self, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog) -> pd.Series:
+        """
+        Calculate AUC for user every user
+        Note that for users without interactions calc_for_user is NaN
+
+        """
         MetricAtK._check(reco, interactions=interactions)
         users = np.array(reco[Columns.User].unique())
         per_user = np.zeros_like(users, dtype=float)
@@ -71,7 +126,22 @@ class AUC(MetricAtK):
 
         return pd.Series(data=per_user, index=users)
 
-    def calc_for_user(self, user_id: ExternalId, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog) -> float:
+    def calc_for_user(
+        self, user_id: ExternalId, reco: pd.DataFrame, interactions: pd.DataFrame, catalog: Catalog
+    ) -> float:
+        """
+        Calculate AUC for user
+        AUC equals to:
+         sum{by positives}sum{by negatives} Indicator(positive scored higher) / num(positives) * num(negatives)
+        where
+        - positives: objects that user has interacted with
+        - negatives: objects that user hasn't interacted with
+        See more: https://en.wikipedia.org/wiki/Receiver_operating_characteristic
+
+        Note that is scores are equal Indicator(...) == 0.5
+        Note that for users without interactions calc_for_user is NaN
+
+        """
         user_reco = reco.loc[reco[Columns.User] == user_id]
         user_interactions = interactions.loc[interactions[Columns.User] == user_id]
         if user_interactions.empty:
@@ -86,13 +156,26 @@ class AUC(MetricAtK):
         return auc_numerator / (len(positives) * len(negatives))
 
     @staticmethod
-    def _auc_positive_scored_higher(positive_item: ExternalId, negative_item: ExternalId, user_reco: pd.DataFrame):
-        pos_score = float(user_reco.loc[user_reco[Columns.Item] == positive_item][Columns.Score]) if not user_reco.loc[user_reco[Columns.Item] == positive_item].empty else 0.0
-        neg_score = float(user_reco.loc[user_reco[Columns.Item] == negative_item][Columns.Score]) if not user_reco.loc[
-            user_reco[Columns.Item] == negative_item].empty else 0.0
+    def _auc_positive_scored_higher(
+        positive_item: ExternalId, negative_item: ExternalId, user_reco: pd.DataFrame
+    ) -> float:
+        """
+        Indicator(positive scored higher)
+        Note that is scores are equal Indicator(...) == 0.5
+
+        """
+        pos_score = (
+            float(user_reco.loc[user_reco[Columns.Item] == positive_item][Columns.Score])
+            if not user_reco.loc[user_reco[Columns.Item] == positive_item].empty
+            else 0.0
+        )
+        neg_score = (
+            float(user_reco.loc[user_reco[Columns.Item] == negative_item][Columns.Score])
+            if not user_reco.loc[user_reco[Columns.Item] == negative_item].empty
+            else 0.0
+        )
         if pos_score > neg_score:
             return 1.0
         if pos_score == neg_score:
             return 0.5
         return 0.0
-

--- a/tests/metrics/test_roc_auc.py
+++ b/tests/metrics/test_roc_auc.py
@@ -1,0 +1,84 @@
+import typing as tp
+
+import numpy as np
+import pandas as pd
+
+from rectools import Columns
+from rectools.metrics import AUC
+from rectools.metrics.base import Catalog
+from rectools.metrics.classification import make_confusions
+
+TP = "__TP"
+FP = "__FP"
+FN = "__FN"
+TN = "__TN"
+
+
+USER_RECO = pd.DataFrame(
+    {
+        Columns.User: [1, 1, 1, 1, 1, 1, 1],
+        Columns.Item: [1, 2, 3, 4, 5, 6, 7],
+        Columns.Rank: [1, 2, 3, 4, 5, 6, 7],
+    }
+)
+
+USER_RECO_SIMPLE = pd.DataFrame(
+    {
+        Columns.User: [1, 1, 1],
+        Columns.Item: [1, 2, 3],
+        Columns.Rank: [1, 2, 3],
+        Columns.Score: [3, 2, 1],
+    }
+)
+
+USER_INTERACTIONS = pd.DataFrame(
+    {
+        Columns.User: [1, 1, 1, 1],
+        Columns.Item: [4, 2, 8, 9],
+    }
+)
+
+USER_INTERACTIONS_SIMPLE = pd.DataFrame(
+    {
+        Columns.User: [1, 1, 1],
+        Columns.Item: [4, 2, 8],
+    }
+)
+
+CATALOG = list(range(20))
+CATALOG_SIMPLE = list(range(1, 9))
+
+
+class TestRoc:
+    def setup(self) -> None:
+        self.k = 7
+        self.metric = AUC(self.k)
+
+    def _make_extended_confusions(
+        self, reco: pd.DataFrame, interactions: pd.DataFrame, k: int, catalog: Catalog
+    ) -> tp.Tuple[np.array, np.array]:
+        confusion_df = make_confusions(reco, interactions, k)
+        if TN not in confusion_df:
+            confusion_df[TN] = len(catalog) - k - confusion_df[FN]
+        return confusion_df
+
+    def test_roc_optimization(self) -> None:
+
+        expected_tpr = np.zeros(self.k + 2)
+        expected_fpr = np.zeros(self.k + 2)
+        expected_tpr[self.k + 1] = 1.0
+        expected_fpr[self.k + 1] = 1.0
+
+        for roc_k in range(1, self.k + 1):
+            confusion_df = self._make_extended_confusions(USER_RECO, USER_INTERACTIONS, roc_k, CATALOG)
+            expected_tpr[roc_k] = confusion_df[TP] / (confusion_df[TP] + confusion_df[FN])
+            expected_fpr[roc_k] = confusion_df[FP] / (confusion_df[FP] + confusion_df[TN])
+
+        tpr, fpr = self.metric._calc_tpr_fpr(USER_RECO, USER_INTERACTIONS, CATALOG)
+
+        assert np.array_equal(expected_tpr, tpr)
+        assert np.array_equal(expected_fpr, fpr)
+
+    def test_auc(self) -> None:
+        expected_auc = 7 / 15
+        assert expected_auc == self.metric.calc_for_user(1, USER_RECO_SIMPLE, USER_INTERACTIONS_SIMPLE, CATALOG_SIMPLE)


### PR DESCRIPTION
Implemented roc-curve and auc, but have some questions:
1) It seems that roc for k extends plot linearly and connect with (1, 1) like: [https://wiki.epfl.ch/edicpublic/documents/Candidacy%20exam/Evaluation.pdf]
But usually it is implemented using scores for all items, but it seems that modelBase doesn't do this. If I tried to use k = len(catalog) (for all elements) some of them were discarded (about 30-50% for user) I've tried debugging, but I'm not sure if it's supposed to work like this.
2) For AUC I've put scores for not recommended elements as 0 (same reason (1)). So it works like LAUC from article from (1)
3) I optimized roc-plot by changing confusion matrix instead of recalculating using make_confusions and went from 15 sec to 1 sec on ratings.dat, but AUC works really slow: more than 30 sec for user. I've tried to use numpy vectorize and broadcasting, but it didn't work because of addressing pandas. I'll try to find a way to do this, but maybe you have suggestions
4) I'm not sure how to test the plot, but tested tpr/fpr calculator. Also I added test for one user auc but didn't add test for all users because of speed.
5) linter passed flake8, but gives codespelling mistake, because it doesn't recognize fpr. I'm not sure if I had to change it in smth like makefile. Maybe you faced similar problem

ROC-curve screenshot:
![ROC-curve screenshot:](https://user-images.githubusercontent.com/79244991/228928435-0a250bdc-113b-4dbb-9fe5-caa6fc294024.png)