### PR TITLE
Metrics. Added Pfound

### DIFF
--- a/rectools/metrics/base.py
+++ b/rectools/metrics/base.py
@@ -76,7 +76,7 @@ def merge_reco(reco: pd.DataFrame, interactions: pd.DataFrame) -> pd.DataFrame:
     Parameters
     ----------
     reco : pd.DataFrame
-        Recommendations table with columns `Columns.User`, `Columns.Item`, `Columns.Rank`.
+        Recommendations table with columns `Columns.User`, `Columns.Item`, `Columns.Rank` and `Columns.Score` (optional)
     interactions : pd.DataFrame
         Interactions table with columns `Columns.User`, `Columns.Item`.
 
@@ -85,9 +85,14 @@ def merge_reco(reco: pd.DataFrame, interactions: pd.DataFrame) -> pd.DataFrame:
     pd.DataFrame
         Result of merging.
     """
+    if Columns.Score in reco:
+        reco_columns = Columns.UserItem + [Columns.Rank, Columns.Score]
+    else:
+        reco_columns = Columns.UserItem + [Columns.Rank]
+
     merged = pd.merge(
         interactions.reindex(columns=Columns.UserItem),
-        reco.reindex(columns=Columns.UserItem + [Columns.Rank]),
+        reco.reindex(columns=reco_columns),
         on=Columns.UserItem,
         how="left",
     )


### PR DESCRIPTION
Implemented a ranking metric PFound@k:

$$pFound@K = \sum_{i=1}^{k} pLook[i]\ pRel[i]$$

$$pLook[1] = 1$$

$$pLook[i] = pLook[i-1]\ (1 - pRel[i-1])\ (1 - pBreak)$$

$$pBreak = 0.15$$

1. Implemented the calculation of the metric, both in the context of each user, and in the context of the overall metric.
2. To calculate this metric, the `Score` column is needed, so I added a condition for the presence of this column to the `merge_reco` function.
3. The calculation of this metric depends on the values of the previous step, so I added a static method that fills in the missed ranks with zero scores. For example, the user has only ranks 1 and 5, to calculate `PFound@6`, you need scores at positions 2, 3, and 4 in order to correctly calculate `pLook[5]`.
4. Wrote tests for metric PFound.