### PR TITLE
Feature/recommend internal ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
 - Ability to pass internal ids to `recommend` and `recommend_to_items` methods and get internal ids back ([#70](https://github.com/MobileTeleSystems/RecTools/pull/70))
+
+### Fixed
+- Small bug in `LastNSplitter` with incorrect `i_split` in info ([#70](https://github.com/MobileTeleSystems/RecTools/pull/70))
 
 
 ## [0.4.1] - 31.10.2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Added
+
+- Ability to pass internal ids to `recommend` and `recommend_to_items` methods and get internal ids back ([#70](https://github.com/MobileTeleSystems/RecTools/pull/70))
+
+
 ## [0.4.1] - 31.10.2023
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -1574,6 +1574,24 @@ toml = "*"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.11.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-mock-3.11.1.tar.gz", hash = "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"},
+    {file = "pytest_mock-3.11.1-py3-none-any.whl", hash = "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "pytest-subtests"
 version = "0.8.0"
 description = "unittest subTest() support and subtests fixture"
@@ -2363,4 +2381,4 @@ torch = ["pytorch-lightning", "torch"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.2, <3.11"
-content-hash = "714d20685aed5242419b010c29b0d346020162a3f929fde73e8bb1655f218c06"
+content-hash = "828865cb13853596ba7e336b579e718e1063f33e29b0490c202738956247dd10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ pytest-subtests = "0.8.0"
 flake8-docstrings = "1.6.0"
 pep8-naming = "0.12.1"
 pytest-cov = "2.12.1"
+pytest-mock = "3.11.1"
 
 
 [tool.black]

--- a/rectools/__init__.py
+++ b/rectools/__init__.py
@@ -34,13 +34,14 @@ Subpackages
 """
 
 from .columns import Columns
-from .types import AnySequence, ExternalId, ExternalIds, InternalId, InternalIds
+from .types import AnyIds, AnySequence, ExternalId, ExternalIds, InternalId, InternalIds
 from .version import VERSION
 
 __version__ = VERSION
 
 __all__ = (
     "Columns",
+    "AnyIds",
     "AnySequence",
     "ExternalId",
     "ExternalIds",

--- a/rectools/model_selection/__init__.py
+++ b/rectools/model_selection/__init__.py
@@ -27,7 +27,6 @@ Splitters
 `model_selection.TimeRangeSplit` - split interactions by time
 """
 
-from .cross_validate import cross_validate
 from .last_n_split import LastNSplitter
 from .random_split import RandomSplitter
 from .splitter import Splitter
@@ -38,5 +37,4 @@ __all__ = (
     "RandomSplitter",
     "LastNSplitter",
     "TimeRangeSplitter",
-    "cross_validate",
 )

--- a/rectools/model_selection/__init__.py
+++ b/rectools/model_selection/__init__.py
@@ -27,6 +27,7 @@ Splitters
 `model_selection.TimeRangeSplit` - split interactions by time
 """
 
+from .cross_validate import cross_validate
 from .last_n_split import LastNSplitter
 from .random_split import RandomSplitter
 from .splitter import Splitter
@@ -37,4 +38,5 @@ __all__ = (
     "RandomSplitter",
     "LastNSplitter",
     "TimeRangeSplitter",
+    "cross_validate",
 )

--- a/rectools/model_selection/last_n_split.py
+++ b/rectools/model_selection/last_n_split.py
@@ -114,6 +114,6 @@ class LastNSplitter(Splitter):
             test_idx = idx[test_mask].values
             train_idx = idx[train_mask].values
 
-            split_info = {"i_split": i_split}
+            split_info = {"i_split": self.n_splits - i_split - 1}
 
             yield train_idx, test_idx, split_info

--- a/rectools/models/base.py
+++ b/rectools/models/base.py
@@ -67,8 +67,8 @@ class ModelBase:
         filter_viewed: bool,
         items_to_recommend: tp.Optional[AnyIds] = None,
         add_rank_col: bool = True,
-        assume_internal_ids: bool = False,
-        return_internal_ids: bool = False,
+        assume_external_ids: bool = True,
+        return_external_ids: bool = True,
     ) -> pd.DataFrame:
         r"""
         Recommend items for users.
@@ -79,7 +79,7 @@ class ModelBase:
         ----------
         users : array-like
             Array of user ids to recommend for.
-            User ids are supposed to be external if `assume_internal_ids` is ``False`` (default).
+            User ids are supposed to be external if `assume_external_ids` is ``True`` (default).
             Internal otherwise.
         dataset : Dataset
             Dataset with input data.
@@ -93,7 +93,7 @@ class ModelBase:
             Whitelist of item ids.
             If given, only these items will be used for recommendations.
             Otherwise all items from dataset will be used.
-            Item ids are supposed to be external if `assume_internal_ids` is `False`` (default).
+            Item ids are supposed to be external if `assume_external_ids` is `True`` (default).
             Internal otherwise.
         add_rank_col : bool, default True
             Whether to add rank column to recommendations.
@@ -101,19 +101,19 @@ class ModelBase:
             This column contain integers from 1 to ``number of user recommendations``.
             In any case recommendations are sorted per rank for every user.
             The lesser the rank the more recommendation is relevant.
-        assume_internal_ids : bool, default False
-            When ``False`` all input user and item ids are supposed to be external.
-            Internal otherwise. Works faster with ``True``.
-        return_internal_ids : bool, default False
-            When ``False`` user and item ids in returning recommendations dataset will be external.
-            Internal otherwise. Works faster with ``True``.
+        assume_external_ids : bool, default True
+            When ``True`` all input user and item ids are supposed to be external.
+            Internal otherwise. Works faster with ``False``.
+        return_external_ids : bool, default True
+            When ``True`` user and item ids in returning recommendations dataset will be external.
+            Internal otherwise. Works faster with ``False``.
 
         Returns
         -------
         pd.DataFrame
             Recommendations table with columns `Columns.User`, `Columns.Item`, `Columns.Score`[, `Columns.Rank`]\.
-            1st column contains external (internal if `return_internal_ids` is ``True``) user ids,
-            2nd - external (internal if `return_internal_ids` is ``True``) ids of recommended items
+            1st column contains external (internal if `return_external_ids` is ``False``) user ids,
+            2nd - external (internal if `return_external_ids` is ``False``) ids of recommended items
                   sorted for each user by relevance,
             3rd - score that model gives for the user-item pair,
             4th (present only if `add_rank_col` is ``True``) - integers from ``1`` to number of user recommendations.
@@ -125,22 +125,24 @@ class ModelBase:
             If called for not fitted model.
         TypeError, ValueError
             If arguments have inappropriate type or value
+        KeyError
+            If some of given users are not in `dataset.user_id_map`
         """
         self._check_is_fitted()
         self._check_k(k)
 
-        if assume_internal_ids:
-            user_ids = np.asarray(users)
-            if not np.issubdtype(user_ids.dtype, np.integer):
-                raise TypeError("Internal user ids are always integer")
-        else:
+        if assume_external_ids:
             try:
                 user_ids = dataset.user_id_map.convert_to_internal(users)
             except KeyError:
                 raise KeyError("All given users must be present in `dataset.user_id_map`")
+        else:
+            user_ids = np.asarray(users)
+            if not np.issubdtype(user_ids.dtype, np.integer):
+                raise TypeError("Internal user ids are always integer")
 
         sorted_item_ids_to_recommend = self._get_sorted_item_ids_to_recommend(
-            items_to_recommend, dataset, assume_internal_ids
+            items_to_recommend, dataset, assume_external_ids
         )
 
         reco_user_ids, reco_item_ids, reco_scores = self._recommend_u2i(
@@ -151,7 +153,7 @@ class ModelBase:
             sorted_item_ids_to_recommend,
         )
 
-        if not return_internal_ids:
+        if return_external_ids:
             reco_user_ids = dataset.user_id_map.convert_to_external(reco_user_ids)
             reco_item_ids = dataset.item_id_map.convert_to_external(reco_item_ids)
 
@@ -166,8 +168,8 @@ class ModelBase:
         filter_itself: bool = True,
         items_to_recommend: tp.Optional[AnyIds] = None,
         add_rank_col: bool = True,
-        assume_internal_ids: bool = False,
-        return_internal_ids: bool = False,
+        assume_external_ids: bool = True,
+        return_external_ids: bool = True,
     ) -> pd.DataFrame:
         """
         Recommend items for target items.
@@ -178,7 +180,7 @@ class ModelBase:
         ----------
         target_items : array-like
             Array of item ids to recommend for.
-            Item ids are supposed to be external if `assume_internal_ids` is `False`` (default).
+            Item ids are supposed to be external if `assume_external_ids` is `True`` (default).
             Internal otherwise.
         dataset : Dataset
             Dataset with input data.
@@ -192,7 +194,7 @@ class ModelBase:
             Whitelist of item ids.
             If given, only these items will be used for recommendations.
             Otherwise all items from dataset will be used.
-            Item ids are supposed to be external if `assume_internal_ids` is `False`` (default).
+            Item ids are supposed to be external if `assume_external_ids` is `True`` (default).
             Internal otherwise.
         add_rank_col : bool, default True
              Whether to add rank column to recommendations.
@@ -200,19 +202,19 @@ class ModelBase:
              This column contain integers from 1 to ``number of item recommendations``.
              In any case recommendations are sorted per rank for every target item.
              Less rank means more relevant recommendation.
-        assume_internal_ids : bool, default False
-            When ``False`` all input item ids are supposed to be external.
-            Internal otherwise. Works faster with ``True``.
-        return_internal_ids : bool, default False
-            When ``False`` item ids in returning recommendations dataset will be external.
-            Internal otherwise. Works faster with ``True``.
+        assume_external_ids : bool, default True
+            When ``True`` all input item ids are supposed to be external.
+            Internal otherwise. Works faster with ``False``.
+        return_external_ids : bool, default True
+            When ``True`` item ids in returning recommendations dataset will be external.
+            Internal otherwise. Works faster with ``False``.
 
         Returns
         -------
         pd.DataFrame
             Recommendations table with columns `Columns.TargetItem`, `Columns.Item`, `Columns.Score`[, `Columns.Rank`].
-            1st column contains external (internal if `return_internal_ids` is ``True``) target item ids,
-            2nd - external (internal if `return_internal_ids` is ``True``) ids of recommended items
+            1st column contains external (internal if `return_external_ids` is ``False``) target item ids,
+            2nd - external (internal if `return_external_ids` is ``False``) ids of recommended items
                   sorted for each target item by relevance,
             3rd - score that model gives for the target-item pair,
             4th (present only if `add_rank_col` is ``True``) - integers from 1 to number of recommendations.
@@ -224,23 +226,24 @@ class ModelBase:
             If called for not fitted model.
         TypeError, ValueError
             If arguments have inappropriate type or value
-
+        KeyError
+            If some of given target items are not in `dataset.item_id_map`
         """
         self._check_is_fitted()
         self._check_k(k)
 
-        if assume_internal_ids:
-            target_ids = np.asarray(target_items)
-            if not np.issubdtype(target_ids.dtype, np.integer):
-                raise TypeError("Internal item ids are always integer")
-        else:
+        if assume_external_ids:
             try:
                 target_ids = dataset.item_id_map.convert_to_internal(target_items)
             except KeyError:
                 raise KeyError("All given target items must be present in `dataset.item_id_map`")
+        else:
+            target_ids = np.asarray(target_items)
+            if not np.issubdtype(target_ids.dtype, np.integer):
+                raise TypeError("Internal item ids are always integer")
 
         sorted_item_ids_to_recommend = self._get_sorted_item_ids_to_recommend(
-            items_to_recommend, dataset, assume_internal_ids
+            items_to_recommend, dataset, assume_external_ids
         )
 
         requested_k = k + 1 if filter_itself else k
@@ -261,7 +264,7 @@ class ModelBase:
             )
             reco_target_ids, reco_item_ids, reco_scores = df_reco[["tid", "iid", "score"]].values.T
 
-        if not return_internal_ids:
+        if return_external_ids:
             reco_target_ids = dataset.item_id_map.convert_to_external(reco_target_ids)
             reco_item_ids = dataset.item_id_map.convert_to_external(reco_item_ids)
 
@@ -320,17 +323,17 @@ class ModelBase:
 
     @classmethod
     def _get_sorted_item_ids_to_recommend(
-        cls, items_to_recommend: tp.Optional[AnyIds], dataset: Dataset, assume_internal_ids: bool
+        cls, items_to_recommend: tp.Optional[AnyIds], dataset: Dataset, assume_external_ids: bool
     ) -> tp.Optional[np.ndarray]:
         if items_to_recommend is None:
             return None
 
-        if assume_internal_ids:
+        if assume_external_ids:
+            item_ids_to_recommend = dataset.item_id_map.convert_to_internal(items_to_recommend, strict=False)
+        else:
             item_ids_to_recommend = np.asarray(items_to_recommend)
             if not np.issubdtype(item_ids_to_recommend.dtype, np.integer):
                 raise TypeError("Internal ids are always integer")
-        else:
-            item_ids_to_recommend = dataset.item_id_map.convert_to_internal(items_to_recommend, strict=False)
-        sorted_item_ids_to_recommend = np.unique(item_ids_to_recommend)
 
+        sorted_item_ids_to_recommend = np.unique(item_ids_to_recommend)
         return sorted_item_ids_to_recommend

--- a/rectools/models/base.py
+++ b/rectools/models/base.py
@@ -105,19 +105,18 @@ class ModelBase:
             When ``True`` all input user and item ids are supposed to be external.
             Internal otherwise. Works faster with ``False``.
         return_external_ids : bool, default True
-            When ``True`` user and item ids in returning recommendations dataset will be external.
+            When ``True`` user and item ids in returning recommendations table will be external.
             Internal otherwise. Works faster with ``False``.
 
         Returns
         -------
         pd.DataFrame
-            Recommendations table with columns `Columns.User`, `Columns.Item`, `Columns.Score`[, `Columns.Rank`]\.
-            1st column contains external (internal if `return_external_ids` is ``False``) user ids,
-            2nd - external (internal if `return_external_ids` is ``False``) ids of recommended items
-                  sorted for each user by relevance,
+            Recommendations table with columns `Columns.User`, `Columns.Item`, `Columns.Score`[, `Columns.Rank`].
+            External user and item ids are used by default. For internal ids set `return_external_ids` to ``False``.
+            1st column contains user ids,
+            2nd - ids of recommended items sorted by relevance for each user,
             3rd - score that model gives for the user-item pair,
             4th (present only if `add_rank_col` is ``True``) - integers from ``1`` to number of user recommendations.
-            Recommendations for every user are always sorted by relevance.
 
         Raises
         ------
@@ -206,19 +205,18 @@ class ModelBase:
             When ``True`` all input item ids are supposed to be external.
             Internal otherwise. Works faster with ``False``.
         return_external_ids : bool, default True
-            When ``True`` item ids in returning recommendations dataset will be external.
+            When ``True`` item ids in returning recommendations table will be external.
             Internal otherwise. Works faster with ``False``.
 
         Returns
         -------
         pd.DataFrame
             Recommendations table with columns `Columns.TargetItem`, `Columns.Item`, `Columns.Score`[, `Columns.Rank`].
-            1st column contains external (internal if `return_external_ids` is ``False``) target item ids,
-            2nd - external (internal if `return_external_ids` is ``False``) ids of recommended items
-                  sorted for each target item by relevance,
+            External item ids are used by default. For internal ids set `return_external_ids` to ``False``.
+            1st column contains target item ids,
+            2nd - ids of recommended items sorted by relevance for each target item,
             3rd - score that model gives for the target-item pair,
             4th (present only if `add_rank_col` is ``True``) - integers from 1 to number of recommendations.
-            Recommendations for every target item are always sorted by relevance.
 
         Raises
         ------

--- a/rectools/types.py
+++ b/rectools/types.py
@@ -20,4 +20,5 @@ ExternalId = tp.Hashable
 ExternalIds = tp.Union[tp.Sequence[ExternalId], np.ndarray]
 InternalId = int
 InternalIds = tp.Union[tp.Sequence[InternalId], np.ndarray]
+AnyIds = tp.Union[ExternalIds, InternalIds]
 AnySequence = tp.Union[tp.Sequence[tp.Any], np.ndarray]

--- a/tests/model_selection/test_last_n_split.py
+++ b/tests/model_selection/test_last_n_split.py
@@ -76,7 +76,7 @@ class TestLastNSplitter:
         assert sorted(actual[1][1]) == to_shuffled([3, 4, 6, 7, 8])
 
         assert actual[0][2] == {
-            "i_split": 1,
+            "i_split": 0,
             "train": 1,
             "train_users": 1,
             "train_items": 1,

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -133,7 +133,7 @@ def test_recommend_from_internal_ids(mocker: MockerFixture) -> None:
         k=2,
         filter_viewed=False,
         items_to_recommend=items_to_recommend,
-        assume_internal_ids=True,
+        assume_external_ids=False,
     )
 
     args, _ = spy.call_args  # args and kwargs properties are unavailable in Python < 3.8
@@ -159,7 +159,7 @@ def test_recommend_from_internal_ids_fails_when_not_integer_ids(users: AnyIds, i
             k=2,
             filter_viewed=False,
             items_to_recommend=items_to_recommend,
-            assume_internal_ids=True,
+            assume_external_ids=False,
         )
 
 
@@ -173,7 +173,7 @@ def test_recommend_returns_internal_ids() -> None:
         filter_viewed=False,
         items_to_recommend=[11, 12],
         add_rank_col=False,
-        return_internal_ids=True,
+        return_external_ids=False,
     )
 
     excepted = pd.DataFrame(
@@ -198,7 +198,7 @@ def test_recommend_to_items_from_internal_ids(mocker: MockerFixture) -> None:
         dataset=DATASET,
         k=2,
         items_to_recommend=items_to_recommend,
-        assume_internal_ids=True,
+        assume_external_ids=False,
     )
 
     args, _ = spy.call_args  # args and kwargs properties are unavailable in Python < 3.8
@@ -225,7 +225,7 @@ def test_recommend_to_items_from_internal_ids_fails_when_not_integer_ids(
             dataset=DATASET,
             k=2,
             items_to_recommend=items_to_recommend,
-            assume_internal_ids=True,
+            assume_external_ids=False,
         )
 
 
@@ -239,7 +239,7 @@ def test_recommend_to_items_returns_internal_ids() -> None:
         items_to_recommend=[11, 12],
         filter_itself=False,
         add_rank_col=False,
-        return_internal_ids=True,
+        return_external_ids=False,
     )
 
     excepted = pd.DataFrame(

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -136,8 +136,9 @@ def test_recommend_from_internal_ids(mocker: MockerFixture) -> None:
         assume_internal_ids=True,
     )
 
-    assert list(spy.call_args.args[0]) == users
-    assert list(spy.call_args.args[4]) == items_to_recommend
+    args, _ = spy.call_args  # args and kwargs properties are unavailable in Python < 3.8
+    assert list(args[0]) == users
+    assert list(args[4]) == items_to_recommend
 
 
 @pytest.mark.parametrize(
@@ -200,8 +201,9 @@ def test_recommend_to_items_from_internal_ids(mocker: MockerFixture) -> None:
         assume_internal_ids=True,
     )
 
-    assert list(spy.call_args.args[0]) == target_items
-    assert list(spy.call_args.args[3]) == items_to_recommend
+    args, _ = spy.call_args  # args and kwargs properties are unavailable in Python < 3.8
+    assert list(args[0]) == target_items
+    assert list(args[3]) == items_to_recommend
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -12,11 +12,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import numpy as np
-import pytest
+import typing as tp
 
+import numpy as np
+import pandas as pd
+import pytest
+from pytest_mock import MockerFixture
+
+from rectools import Columns
+from rectools.dataset import Dataset
 from rectools.exceptions import NotFittedError
-from rectools.models.base import ModelBase
+from rectools.models.base import ModelBase, Scores
+from rectools.types import AnyIds, InternalIds
 
 from .data import DATASET
 
@@ -88,3 +95,157 @@ def test_raise_when_k_is_not_positive_i2i(k: int) -> None:
             dataset=DATASET,
             k=k,
         )
+
+
+class SomeModel(ModelBase):
+    def _fit(self, dataset: Dataset, *args: tp.Any, **kwargs: tp.Any) -> None:
+        pass
+
+    def _recommend_u2i(
+        self,
+        user_ids: np.ndarray,
+        dataset: Dataset,
+        k: int,
+        filter_viewed: bool,
+        sorted_item_ids_to_recommend: tp.Optional[np.ndarray],
+    ) -> tp.Tuple[InternalIds, InternalIds, Scores]:
+        return [0, 0, 1], [0, 1, 2], [0.1, 0.2, 0.3]
+
+    def _recommend_i2i(
+        self,
+        target_ids: np.ndarray,
+        dataset: Dataset,
+        k: int,
+        sorted_item_ids_to_recommend: tp.Optional[np.ndarray],
+    ) -> tp.Tuple[InternalIds, InternalIds, Scores]:
+        return [0, 0, 1], [0, 1, 2], [0.1, 0.2, 0.3]
+
+
+def test_recommend_from_internal_ids(mocker: MockerFixture) -> None:
+    model = SomeModel().fit(DATASET)
+    users = [0, 1, 2]
+    items_to_recommend = [0, 1, 2]
+
+    spy = mocker.spy(model, "_recommend_u2i")
+    model.recommend(
+        users=users,
+        dataset=DATASET,
+        k=2,
+        filter_viewed=False,
+        items_to_recommend=items_to_recommend,
+        assume_internal_ids=True,
+    )
+
+    assert list(spy.call_args.args[0]) == users
+    assert list(spy.call_args.args[4]) == items_to_recommend
+
+
+@pytest.mark.parametrize(
+    "users, items_to_recommend",
+    (
+        (["u1", "u2"], [0, 1]),
+        ([0, 1], ["i1", "i2"]),
+        (["u1", "u2"], ["i1", "i2"]),
+    ),
+)
+def test_recommend_from_internal_ids_fails_when_not_integer_ids(users: AnyIds, items_to_recommend: AnyIds) -> None:
+    model = SomeModel().fit(DATASET)
+
+    with pytest.raises(TypeError):
+        model.recommend(
+            users=users,
+            dataset=DATASET,
+            k=2,
+            filter_viewed=False,
+            items_to_recommend=items_to_recommend,
+            assume_internal_ids=True,
+        )
+
+
+def test_recommend_returns_internal_ids() -> None:
+    model = SomeModel().fit(DATASET)
+
+    reco = model.recommend(
+        users=[10, 20],
+        dataset=DATASET,
+        k=2,
+        filter_viewed=False,
+        items_to_recommend=[11, 12],
+        add_rank_col=False,
+        return_internal_ids=True,
+    )
+
+    excepted = pd.DataFrame(
+        {
+            Columns.User: [0, 0, 1],
+            Columns.Item: [0, 1, 2],
+            Columns.Score: [0.1, 0.2, 0.3],
+        }
+    )
+
+    pd.testing.assert_frame_equal(reco, excepted)
+
+
+def test_recommend_to_items_from_internal_ids(mocker: MockerFixture) -> None:
+    model = SomeModel().fit(DATASET)
+    target_items = [0, 1, 2]
+    items_to_recommend = [0, 1, 2]
+
+    spy = mocker.spy(model, "_recommend_i2i")
+    model.recommend_to_items(
+        target_items=target_items,
+        dataset=DATASET,
+        k=2,
+        items_to_recommend=items_to_recommend,
+        assume_internal_ids=True,
+    )
+
+    assert list(spy.call_args.args[0]) == target_items
+    assert list(spy.call_args.args[3]) == items_to_recommend
+
+
+@pytest.mark.parametrize(
+    "target_items, items_to_recommend",
+    (
+        (["i1", "i2"], [0, 1]),
+        ([0, 1], ["i1", "i2"]),
+        (["i1", "i2"], ["i1", "i2"]),
+    ),
+)
+def test_recommend_to_items_from_internal_ids_fails_when_not_integer_ids(
+    target_items: AnyIds, items_to_recommend: AnyIds
+) -> None:
+    model = SomeModel().fit(DATASET)
+
+    with pytest.raises(TypeError):
+        model.recommend_to_items(
+            target_items=target_items,
+            dataset=DATASET,
+            k=2,
+            items_to_recommend=items_to_recommend,
+            assume_internal_ids=True,
+        )
+
+
+def test_recommend_to_items_returns_internal_ids() -> None:
+    model = SomeModel().fit(DATASET)
+
+    reco = model.recommend_to_items(
+        target_items=[11, 12],
+        dataset=DATASET,
+        k=2,
+        items_to_recommend=[11, 12],
+        filter_itself=False,
+        add_rank_col=False,
+        return_internal_ids=True,
+    )
+
+    excepted = pd.DataFrame(
+        {
+            Columns.TargetItem: [0, 0, 1],
+            Columns.Item: [0, 1, 2],
+            Columns.Score: [0.1, 0.2, 0.3],
+        }
+    )
+
+    pd.testing.assert_frame_equal(reco, excepted)


### PR DESCRIPTION
- Added ability to pass internal ids to `recommend` and `recommend_to_items` methods and get internal ids back
- Fixed bug in `LastNSplitter` with incorrect `i_split` in info