### PR TITLE
Feature/ease

### DIFF
--- a/rectools/models/__init__.py
+++ b/rectools/models/__init__.py
@@ -26,6 +26,7 @@ implementations.
 Models
 ------
 `models.DSSMModel`
+`models.EASE`
 `models.ImplicitALSWrapperModel`
 `models.ImplicitItemKNNWrapperModel`
 `models.LightFMWrapperModel`
@@ -35,6 +36,7 @@ Models
 `models.RandomModel`
 """
 
+from .ease import EASEModel
 from .implicit_als import ImplicitALSWrapperModel
 from .implicit_knn import ImplicitItemKNNWrapperModel
 from .popular import PopularModel
@@ -54,6 +56,7 @@ except ImportError:  # pragma: no cover
 
 
 __all__ = (
+    "EASEModel",
     "ImplicitALSWrapperModel",
     "ImplicitItemKNNWrapperModel",
     "LightFMWrapperModel",

--- a/rectools/models/ease.py
+++ b/rectools/models/ease.py
@@ -101,8 +101,8 @@ class EASE(ModelBase):
             viewed_ids = get_viewed_item_ids(user_items, user_id)  # sorted
         else:
             viewed_ids = np.array([], dtype=int)
-
-        scores = user_items[user_id].dot(self.weight).getA1()
+        
+        scores = (user_items[user_id] @ self.weight).getA1()
         reco_ids, reco_scores = recommend_from_scores(
             scores=scores, k=k, sorted_blacklist=viewed_ids, sorted_whitelist=sorted_item_ids
         )

--- a/rectools/models/ease.py
+++ b/rectools/models/ease.py
@@ -24,8 +24,8 @@ from rectools import InternalIds
 from rectools.dataset import Dataset
 
 from .base import ModelBase, Scores
+from .utils import recommend_from_scores
 from .vector import Distance, ImplicitRanker
-from .utils import get_viewed_item_ids, recommend_from_scores
 
 
 class EASEModel(ModelBase):

--- a/rectools/models/ease.py
+++ b/rectools/models/ease.py
@@ -62,7 +62,7 @@ class EASEModel(ModelBase):
 
         gram_matrix_inv = np.linalg.inv(gram_matrix)
 
-        self.weight = np.array(gram_matrix / (-np.diag(gram_matrix_inv)))
+        self.weight = np.array(gram_matrix_inv / (-np.diag(gram_matrix_inv)))
         np.fill_diagonal(self.weight, 0.0)
 
     def _recommend_u2i(

--- a/tests/models/test_ease.py
+++ b/tests/models/test_ease.py
@@ -40,7 +40,7 @@ class TestEASEModel:
                     {
                         Columns.User: [10, 10, 20, 20],
                         Columns.Item: [15, 13, 14, 15],
-                        Columns.Score: np.array([0.00788948, 0.0039526 , 0.00789337, 0.00590922], dtype=np.float32),
+                        Columns.Score: np.array([0.00788948, 0.0039526, 0.00789337, 0.00590922], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),

--- a/tests/models/test_ease.py
+++ b/tests/models/test_ease.py
@@ -39,8 +39,8 @@ class TestEASEModel:
                 pd.DataFrame(
                     {
                         Columns.User: [10, 10, 20, 20],
-                        Columns.Item: [17, 13, 17, 15],
-                        Columns.Score: np.array([-503.96243, -1006.93286, -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Item: [15, 13, 14, 15],
+                        Columns.Score: np.array([0.00788948, 0.0039526 , 0.00789337, 0.00590922], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
@@ -50,8 +50,8 @@ class TestEASEModel:
                 pd.DataFrame(
                     {
                         Columns.User: [10, 10, 20, 20],
-                        Columns.Item: [17, 13, 17, 13],
-                        Columns.Score: np.array([-503.96243, -1006.93286, -503.96243, -1006.93286], dtype=np.float32),
+                        Columns.Item: [12, 11, 12, 11],
+                        Columns.Score: np.array([0.00988546, 0.00986199, 0.00791307, 0.00789747], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
@@ -77,8 +77,8 @@ class TestEASEModel:
                 pd.DataFrame(
                     {
                         Columns.User: [10, 10, 20, 20],
-                        Columns.Item: [17, 15, 17, 15],
-                        Columns.Score: np.array([-503.96243, -2012.8776, -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Item: [15, 17, 15, 17],
+                        Columns.Score: np.array([0.00788948, 0.00196058, 0.00590922, 0.00196845], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
@@ -88,8 +88,8 @@ class TestEASEModel:
                 pd.DataFrame(
                     {
                         Columns.User: [10, 10, 20, 20],
-                        Columns.Item: [17, 15, 17, 15],
-                        Columns.Score: np.array([-503.96243, -2012.8776, -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Item: [11, 15, 11, 15],
+                        Columns.Score: np.array([0.00986199, 0.00788948, 0.00789747, 0.00590922], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
@@ -128,7 +128,7 @@ class TestEASEModel:
                 pd.DataFrame(
                     {
                         Columns.TargetItem: [11, 11, 12, 12],
-                        Columns.Item: [11, 13, 17, 12],
+                        Columns.Item: [12, 15, 11, 14],
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
@@ -139,7 +139,7 @@ class TestEASEModel:
                 pd.DataFrame(
                     {
                         Columns.TargetItem: [11, 11, 12, 12],
-                        Columns.Item: [13, 17, 17, 13],
+                        Columns.Item: [12, 15, 11, 14],
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
@@ -150,7 +150,7 @@ class TestEASEModel:
                 pd.DataFrame(
                     {
                         Columns.TargetItem: [11, 11, 12, 12],
-                        Columns.Item: [11, 13, 13, 14],
+                        Columns.Item: [14, 13, 11, 14],
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),

--- a/tests/models/test_ease.py
+++ b/tests/models/test_ease.py
@@ -1,0 +1,182 @@
+#  Copyright 2022 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import typing as tp
+from copy import deepcopy
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rectools import Columns
+from rectools.dataset import Dataset
+from rectools.models import EASEModel
+
+from .data import DATASET
+from .utils import assert_second_fit_refits_model
+
+
+class TestEASEModel:
+    @pytest.fixture
+    def dataset(self) -> Dataset:
+        return DATASET
+    
+    @pytest.mark.parametrize(
+        "filter_viewed,expected",
+        (
+            (
+                True,
+                pd.DataFrame(
+                    {
+                        Columns.User: [10, 10, 20, 20],
+                        Columns.Item: [17, 13, 17, 15],
+                        Columns.Score: np.array([-503.96243, -1006.93286,  -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Rank: [1, 2, 1, 2],
+                    }
+                ),
+            ),
+            (
+                False,
+                pd.DataFrame(
+                    {
+                        Columns.User: [10, 10, 20, 20],
+                        Columns.Item: [17, 13, 17, 13],
+                        Columns.Score: np.array([-503.96243, -1006.93286,  -503.96243, -1006.93286], dtype=np.float32),
+                        Columns.Rank: [1, 2, 1, 2],
+                    }
+                ),
+            ),
+        ),
+    )
+    def test_basic(self, dataset: Dataset, filter_viewed: bool, expected: pd.DataFrame):
+        model = EASEModel(regularization=500).fit(dataset)
+        actual = model.recommend(
+            users=np.array([10, 20]),
+            dataset=dataset,
+            k=2,
+            filter_viewed=filter_viewed,
+        )
+        tol_kwargs: tp.Dict[str, float] = {"check_less_precise": 3} if pd.__version__ < "1" else {"atol": 0.001}
+        pd.testing.assert_frame_equal(actual, expected, **tol_kwargs)  # pylint: disable = unexpected-keyword-arg
+
+    @pytest.mark.parametrize(
+        "filter_viewed,expected",
+        (
+            (
+                True,
+                pd.DataFrame(
+                    {
+                        Columns.User: [10, 10, 20, 20],
+                        Columns.Item: [17, 15, 17, 15],
+                        Columns.Score: np.array([-503.96243, -2012.8776,  -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Rank: [1, 2, 1, 2],
+                    }
+                ),
+            ),
+            (
+                False,
+                pd.DataFrame(
+                    {
+                        Columns.User: [10, 10, 20, 20],
+                        Columns.Item: [17, 15, 17, 15],
+                        Columns.Score: np.array([-503.96243, -2012.8776,  -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Rank: [1, 2, 1, 2],
+                    }
+                ),
+            ),
+        ),
+    )
+    def test_with_whitelist(self, dataset: Dataset, filter_viewed: bool, expected: pd.DataFrame):
+        model = EASEModel(regularization=500).fit(dataset)
+        actual = model.recommend(
+            users=np.array([10, 20]),
+            dataset=dataset,
+            k=2,
+            filter_viewed=filter_viewed,
+            items_to_recommend=np.array([11, 15, 17]),
+        )
+        tol_kwargs: tp.Dict[str, float] = {"check_less_precise": 3} if pd.__version__ < "1" else {"atol": 0.001}
+        pd.testing.assert_frame_equal(actual, expected, **tol_kwargs)  # pylint: disable = unexpected-keyword-arg
+
+    @pytest.mark.parametrize("filter_viewed", (True, False))
+    def test_raises_when_new_user(self, dataset, filter_viewed):
+        model = EASEModel(regularization=500).fit(dataset)
+        with pytest.raises(KeyError):
+            model.recommend(
+                users=np.array([10, 50]),
+                dataset=dataset,
+                k=2,
+                filter_viewed=filter_viewed,
+            )
+
+    @pytest.mark.parametrize(
+        "filter_itself,whitelist,expected",
+        (
+            (
+                False,
+                None,
+                pd.DataFrame(
+                    {
+                        Columns.TargetItem: [11, 11, 12, 12],
+                        Columns.Item: [11, 13, 17, 12],
+                        Columns.Rank: [1, 2, 1, 2],
+                    }
+                ),
+            ),
+            (
+                True,
+                None,
+                pd.DataFrame(
+                    {
+                        Columns.TargetItem: [11, 11, 12, 12],
+                        Columns.Item: [13, 17, 17, 13],
+                        Columns.Rank: [1, 2, 1, 2],
+                    }
+                ),
+            ),
+            (
+                False,
+                np.array([11, 13, 14]),
+                pd.DataFrame(
+                    {
+                        Columns.TargetItem: [11, 11, 12, 12],
+                        Columns.Item: [11, 13, 13, 14],
+                        Columns.Rank: [1, 2, 1, 2],
+                    }
+                ),
+            ),
+        ),
+    )
+    def test_i2i(
+        self, dataset: Dataset, filter_itself: bool, whitelist: tp.Optional[np.ndarray], expected: pd.DataFrame
+    ) -> None:
+        model = EASEModel(regularization=500).fit(dataset)
+        actual = model.recommend_to_items(
+            target_items=np.array([11, 12]),
+            dataset=dataset,
+            k=2,
+            filter_itself=filter_itself,
+            items_to_recommend=whitelist,
+        )
+        pd.testing.assert_frame_equal(actual.drop(columns=Columns.Score), expected)
+        pd.testing.assert_frame_equal(
+            actual.sort_values([Columns.TargetItem, Columns.Score], ascending=[True, False]).reset_index(drop=True),
+            actual,
+        )
+
+    def test_second_fit_refits_model(self, dataset: Dataset) -> None:
+        model = EASEModel()
+        assert_second_fit_refits_model(model, dataset)
+    
+

--- a/tests/models/test_ease.py
+++ b/tests/models/test_ease.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 import typing as tp
-from copy import deepcopy
 
 import numpy as np
 import pandas as pd
@@ -31,7 +30,7 @@ class TestEASEModel:
     @pytest.fixture
     def dataset(self) -> Dataset:
         return DATASET
-    
+
     @pytest.mark.parametrize(
         "filter_viewed,expected",
         (
@@ -41,7 +40,7 @@ class TestEASEModel:
                     {
                         Columns.User: [10, 10, 20, 20],
                         Columns.Item: [17, 13, 17, 15],
-                        Columns.Score: np.array([-503.96243, -1006.93286,  -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Score: np.array([-503.96243, -1006.93286, -503.96243, -1510.8953], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
@@ -52,14 +51,14 @@ class TestEASEModel:
                     {
                         Columns.User: [10, 10, 20, 20],
                         Columns.Item: [17, 13, 17, 13],
-                        Columns.Score: np.array([-503.96243, -1006.93286,  -503.96243, -1006.93286], dtype=np.float32),
+                        Columns.Score: np.array([-503.96243, -1006.93286, -503.96243, -1006.93286], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
             ),
         ),
     )
-    def test_basic(self, dataset: Dataset, filter_viewed: bool, expected: pd.DataFrame):
+    def test_basic(self, dataset: Dataset, filter_viewed: bool, expected: pd.DataFrame) -> None:
         model = EASEModel(regularization=500).fit(dataset)
         actual = model.recommend(
             users=np.array([10, 20]),
@@ -79,7 +78,7 @@ class TestEASEModel:
                     {
                         Columns.User: [10, 10, 20, 20],
                         Columns.Item: [17, 15, 17, 15],
-                        Columns.Score: np.array([-503.96243, -2012.8776,  -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Score: np.array([-503.96243, -2012.8776, -503.96243, -1510.8953], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
@@ -90,14 +89,14 @@ class TestEASEModel:
                     {
                         Columns.User: [10, 10, 20, 20],
                         Columns.Item: [17, 15, 17, 15],
-                        Columns.Score: np.array([-503.96243, -2012.8776,  -503.96243, -1510.8953], dtype=np.float32),
+                        Columns.Score: np.array([-503.96243, -2012.8776, -503.96243, -1510.8953], dtype=np.float32),
                         Columns.Rank: [1, 2, 1, 2],
                     }
                 ),
             ),
         ),
     )
-    def test_with_whitelist(self, dataset: Dataset, filter_viewed: bool, expected: pd.DataFrame):
+    def test_with_whitelist(self, dataset: Dataset, filter_viewed: bool, expected: pd.DataFrame) -> None:
         model = EASEModel(regularization=500).fit(dataset)
         actual = model.recommend(
             users=np.array([10, 20]),
@@ -110,7 +109,7 @@ class TestEASEModel:
         pd.testing.assert_frame_equal(actual, expected, **tol_kwargs)  # pylint: disable = unexpected-keyword-arg
 
     @pytest.mark.parametrize("filter_viewed", (True, False))
-    def test_raises_when_new_user(self, dataset, filter_viewed):
+    def test_raises_when_new_user(self, dataset: Dataset, filter_viewed: bool) -> None:
         model = EASEModel(regularization=500).fit(dataset)
         with pytest.raises(KeyError):
             model.recommend(
@@ -178,5 +177,3 @@ class TestEASEModel:
     def test_second_fit_refits_model(self, dataset: Dataset) -> None:
         model = EASEModel()
         assert_second_fit_refits_model(model, dataset)
-    
-


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/MobileTeleSystems/RecTools/blob/master/CONTRIBUTING.rst
-->

## Description

<!--
Explain the context and why you're making the change. What is the problem
you're trying to solve?
-->
Implementation of the [ease](https://arxiv.org/pdf/1905.03375.pdf) model

For u2i recommendations I use ImplicitRanker. It's in the [vector.py](https://github.com/MobileTeleSystems/RecTools/blob/main/rectools/models/vector.py#L47), but the EASE model is inherited from [ModelBase](https://github.com/MobileTeleSystems/RecTools/blob/main/rectools/models/base.py#L30). In addition, ImplicitRanker accepts [subjects_factors as input, like np.ndarray](https://github.com/MobileTeleSystems/RecTools/blob/main/rectools/models/vector.py#L61), but I pass scipy.sparse.csr_matrix as input, which speeds up the inference a little.
I propose to move ImplicitRanker into a separate module and add types of accepted objects.

## Type of change

<!--
Please delete/mark options that are/aren't relevant
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Optimization

## How Has This Been Tested?
Before submitting a PR, please check yourself against the following list. It would save us quite a lot of time.
- Have you read the contribution guide?
- Have you updated the relevant docstrings? We're using Numpy format, please double-check yourself
- Does your change require any new tests?
- Have you updated the changelog file?

<!--
Should you feel your tests need an explanation or clarification, please put your description here. 
Otherwise feel free to remove this section.
-->
