### PR TITLE
Fix/pop in cat refit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Used the latest version of `lightfm` that allows to install it using `poetry>=1.5.0` ([#141](https://github.com/MobileTeleSystems/RecTools/pull/141))
 - Added restriction to `pytorch` version for MacOSX + x86_64 that allows to install it on such platforms ([#142](https://github.com/MobileTeleSystems/RecTools/pull/142))
+- `PopularInCategoryModel` fitting for multiple times and `cross_validate` compatibility
 
 
 ## [0.6.0] - 13.05.2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Used the latest version of `lightfm` that allows to install it using `poetry>=1.5.0` ([#141](https://github.com/MobileTeleSystems/RecTools/pull/141))
 - Added restriction to `pytorch` version for MacOSX + x86_64 that allows to install it on such platforms ([#142](https://github.com/MobileTeleSystems/RecTools/pull/142))
-- `PopularInCategoryModel` fitting for multiple times and `cross_validate` compatibility
+- `PopularInCategoryModel` fitting for multiple times, `cross_validate` compatibility, behaviour with empty category interactions
 
 
 ## [0.6.0] - 13.05.2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Used the latest version of `lightfm` that allows to install it using `poetry>=1.5.0` ([#141](https://github.com/MobileTeleSystems/RecTools/pull/141))
 - Added restriction to `pytorch` version for MacOSX + x86_64 that allows to install it on such platforms ([#142](https://github.com/MobileTeleSystems/RecTools/pull/142))
-- `PopularInCategoryModel` fitting for multiple times, `cross_validate` compatibility, behaviour with empty category interactions
+- `PopularInCategoryModel` fitting for multiple times, `cross_validate` compatibility, behaviour with empty category interactions ([#163](https://github.com/MobileTeleSystems/RecTools/pull/163))
 
 
 ## [0.6.0] - 13.05.2024

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@
   <a href="https://rectools.readthedocs.io/en/stable/">Documentation</a> |
   <a href="https://github.com/MobileTeleSystems/RecTools/tree/main/examples">Examples</a> |
     <a href="https://github.com/MobileTeleSystems/RecTools/tree/main/examples/tutorials">Tutorials</a> |
-  <a href="https://github.com/MobileTeleSystems/RecTools/blob/main/CONTRIBUTING.rst">Contribution Guide</a> |
-  <a href="https://github.com/MobileTeleSystems/RecTools/releases">Release Notes</a>
+  <a href="https://github.com/MobileTeleSystems/RecTools/blob/main/CONTRIBUTING.rst">Contributing</a> |
+  <a href="https://github.com/MobileTeleSystems/RecTools/releases">Releases</a> |
+  <a href="https://github.com/orgs/MobileTeleSystems/projects/1">Developers Board</a>
 </p>
 
 RecTools is an easy-to-use Python library which makes the process of building recommendation systems easier, 

--- a/rectools/models/popular_in_category.py
+++ b/rectools/models/popular_in_category.py
@@ -171,8 +171,8 @@ class PopularInCategoryModel(PopularModel):
                 self.category_interactions[column_num] = category_interactions.copy()
                 col, func = self._get_groupby_col_and_agg_func(self.popularity)
                 scores_dict[column_num] = self.category_interactions[column_num][col].apply(func)
-        if empty_columns:
-            self.category_columns = [col for col in self.category_columns if col not in empty_columns]
+
+        self.category_columns = [col for col in self.category_columns if col not in empty_columns]
         self.category_scores = pd.Series(scores_dict).sort_values(ascending=False)
 
     def _define_categories_for_analysis(self) -> None:
@@ -193,12 +193,11 @@ class PopularInCategoryModel(PopularModel):
 
     def _fit(self, dataset: Dataset) -> None:  # type: ignore
 
-        if self.is_fitted:
-            self.category_columns = []
-            self.category_interactions = {}
-            self.models = {}
-            self.category_scores = pd.Series()
-            self.n_effective_categories = 0
+        self.category_columns = []
+        self.category_interactions = {}
+        self.models = {}
+        self.category_scores = pd.Series()
+        self.n_effective_categories = 0
 
         self._check_category_feature(dataset)
         interactions = self._filter_interactions(dataset.interactions.df)

--- a/rectools/models/popular_in_category.py
+++ b/rectools/models/popular_in_category.py
@@ -160,15 +160,19 @@ class PopularInCategoryModel(PopularModel):
 
     def _calc_category_scores(self, dataset: Dataset, interactions: pd.DataFrame) -> None:
         scores_dict = {}
+        empty_columns = []
         for column_num in self.category_columns:
             item_idx = dataset.item_features.values.getcol(column_num).nonzero()[0]  # type: ignore
-            self.category_interactions[column_num] = interactions[interactions[Columns.Item].isin(item_idx)].copy()
+            category_interactions = interactions[interactions[Columns.Item].isin(item_idx)]
             # Category interactions might be empty
-            if self.category_interactions[column_num].shape[0] == 0:
-                self.category_columns.remove(column_num)
+            if category_interactions.shape[0] == 0:
+                empty_columns.append(column_num)
             else:
+                self.category_interactions[column_num] = category_interactions.copy()
                 col, func = self._get_groupby_col_and_agg_func(self.popularity)
                 scores_dict[column_num] = self.category_interactions[column_num][col].apply(func)
+        if empty_columns:
+            self.category_columns = [col for col in self.category_columns if col not in empty_columns]
         self.category_scores = pd.Series(scores_dict).sort_values(ascending=False)
 
     def _define_categories_for_analysis(self) -> None:
@@ -188,14 +192,14 @@ class PopularInCategoryModel(PopularModel):
             self.n_effective_categories = len(self.category_columns)
 
     def _fit(self, dataset: Dataset) -> None:  # type: ignore
-        
+
         if self.is_fitted:
             self.category_columns = []
             self.category_interactions = {}
             self.models = {}
             self.category_scores = pd.Series()
             self.n_effective_categories = 0
-        
+
         self._check_category_feature(dataset)
         interactions = self._filter_interactions(dataset.interactions.df)
         self._calc_category_scores(dataset, interactions)

--- a/rectools/models/popular_in_category.py
+++ b/rectools/models/popular_in_category.py
@@ -175,9 +175,9 @@ class PopularInCategoryModel(PopularModel):
         if self.n_categories:
             if len(self.category_columns) >= self.n_categories:
                 self.n_effective_categories = self.n_categories
-                relevant_categories = self.category_scores.head(self.n_categories).index.to_list()
+                relevant_categories = self.category_scores.head(self.n_categories).index
                 self.category_scores = self.category_scores.loc[relevant_categories]
-                self.category_columns = relevant_categories
+                self.category_columns = relevant_categories.to_list()
             else:
                 self.n_effective_categories = len(self.category_columns)
                 warnings.warn(

--- a/rectools/models/popular_in_category.py
+++ b/rectools/models/popular_in_category.py
@@ -175,7 +175,7 @@ class PopularInCategoryModel(PopularModel):
         if self.n_categories:
             if len(self.category_columns) >= self.n_categories:
                 self.n_effective_categories = self.n_categories
-                relevant_categories = self.category_scores.head(self.n_categories).index
+                relevant_categories = self.category_scores.head(self.n_categories).index.to_list()
                 self.category_scores = self.category_scores.loc[relevant_categories]
                 self.category_columns = relevant_categories
             else:
@@ -188,6 +188,14 @@ class PopularInCategoryModel(PopularModel):
             self.n_effective_categories = len(self.category_columns)
 
     def _fit(self, dataset: Dataset) -> None:  # type: ignore
+        
+        if self.is_fitted:
+            self.category_columns = []
+            self.category_interactions = {}
+            self.models = {}
+            self.category_scores = pd.Series()
+            self.n_effective_categories = 0
+        
         self._check_category_feature(dataset)
         interactions = self._filter_interactions(dataset.interactions.df)
         self._calc_category_scores(dataset, interactions)

--- a/tests/model_selection/test_cross_validate.py
+++ b/tests/model_selection/test_cross_validate.py
@@ -244,7 +244,7 @@ class TestCrossValidate:
 
     @pytest.mark.parametrize("prefer_warm_inference_over_cold", (True, False))
     def test_happy_path_with_features(self, prefer_warm_inference_over_cold: bool) -> None:
-        splitter = LastNSplitter(n=1, n_splits=2, filter_cold_items=False, filter_already_seen=False)  # 2 splits
+        splitter = LastNSplitter(n=1, n_splits=2, filter_cold_items=False, filter_already_seen=False)
 
         models: tp.Dict[str, ModelBase] = {
             "als": ImplicitALSWrapperModel(AlternatingLeastSquares(factors=2, iterations=2, random_state=42)),

--- a/tests/models/test_popular_in_category.py
+++ b/tests/models/test_popular_in_category.py
@@ -422,11 +422,25 @@ class TestPopularInCategoryModel:
             actual,
         )
 
-    def test_second_fit_refits_model(self, dataset: Dataset) -> None:
+    @pytest.mark.parametrize("popularity", ("mean_weight", "n_users", "n_interactions"))
+    @pytest.mark.parametrize("category_feature", ("f1", "f2"))
+    @pytest.mark.parametrize("mixing_strategy", ("group", "rotate"))
+    @pytest.mark.parametrize("ratio_strategy", ("equal", "proportional"))
+    @pytest.mark.parametrize("n_categories", (2, None))
+    def test_second_fit_refits_model(
+        self, 
+        dataset: Dataset,
+        popularity: str,
+        category_feature: str,
+        mixing_strategy: str,
+        ratio_strategy: str,
+        n_categories: tp.Optional[int]
+        ) -> None:
         model = PopularInCategoryModel(
-            category_feature="f2",
-            popularity="mean_weight",
-            mixing_strategy="group",
-            ratio_strategy="proportional",
+            category_feature=category_feature,
+            popularity=popularity,
+            mixing_strategy=mixing_strategy,
+            ratio_strategy=ratio_strategy,
+            n_categories=n_categories
         )
         assert_second_fit_refits_model(model, dataset)

--- a/tests/models/test_popular_in_category.py
+++ b/tests/models/test_popular_in_category.py
@@ -428,19 +428,19 @@ class TestPopularInCategoryModel:
     @pytest.mark.parametrize("ratio_strategy", ("equal", "proportional"))
     @pytest.mark.parametrize("n_categories", (2, None))
     def test_second_fit_refits_model(
-        self, 
+        self,
         dataset: Dataset,
         popularity: str,
         category_feature: str,
         mixing_strategy: str,
         ratio_strategy: str,
-        n_categories: tp.Optional[int]
-        ) -> None:
+        n_categories: tp.Optional[int],
+    ) -> None:
         model = PopularInCategoryModel(
             category_feature=category_feature,
             popularity=popularity,
             mixing_strategy=mixing_strategy,
             ratio_strategy=ratio_strategy,
-            n_categories=n_categories
+            n_categories=n_categories,
         )
         assert_second_fit_refits_model(model, dataset)


### PR DESCRIPTION
- Fixed `PopularInCategoryModel` refit behaviour and `cross-validate` compatibility
- Fixed `PopularInCategoryModel` empty category interactions behaviour
- Added tests
Closes https://github.com/MobileTeleSystems/RecTools/issues/162