### PR TITLE
Removed internal ids usage outside models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `Debias` mechanism for classification, ranking and auc metrics. New parameter `is_debiased` to `calc_from_confusion_df`, `calc_per_user_from_confusion_df` methods of classification metrics, `calc_from_fitted`, `calc_per_user_from_fitted` methods of auc and rankning (`MAP`) metrics, `calc_from_merged`, `calc_per_user_from_merged` methods of ranking (`NDCG`, `MRR`) metrics. ([#152](https://github.com/MobileTeleSystems/RecTools/pull/152))
 - `filter_on_interactions_df_row_indexes` method of `Dataset` ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
+- `on_unsupported_targets` parameter to  `recommend` and `recommend_to_items` model methods ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
 
 ### Removed
 - [Breaking] `assume_external_ids` parameter in `recommend` and `recommend_to_items` model methods ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `Debias` mechanism for classification, ranking and auc metrics. New parameter `is_debiased` to `calc_from_confusion_df`, `calc_per_user_from_confusion_df` methods of classification metrics, `calc_from_fitted`, `calc_per_user_from_fitted` methods of auc and rankning (`MAP`) metrics, `calc_from_merged`, `calc_per_user_from_merged` methods of ranking (`NDCG`, `MRR`) metrics. ([#152](https://github.com/MobileTeleSystems/RecTools/pull/152))
 - `nbformat >= 4.2.0` dependency to `[visuals]` extra ([#169](https://github.com/MobileTeleSystems/RecTools/pull/169))
-- `filter_on_interactions_df_row_indexes` method of `Dataset` ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
+- `filter_interactions` method of `Dataset` ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
 - `on_unsupported_targets` parameter to  `recommend` and `recommend_to_items` model methods ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Debias` mechanism for classification, ranking and auc metrics. New parameter `is_debiased` to `calc_from_confusion_df`, `calc_per_user_from_confusion_df` methods of classification metrics, `calc_from_fitted`, `calc_per_user_from_fitted` methods of auc and rankning (`MAP`) metrics, `calc_from_merged`, `calc_per_user_from_merged` methods of ranking (`NDCG`, `MRR`) metrics. ([#152](https://github.com/MobileTeleSystems/RecTools/pull/152))
+- `filter_on_interactions_df_row_indexes` method of `Dataset`
+
+### Removed
+- [Breaking] `assume_external_ids` parameter in `recommend` and `recommend_to_items` model methods 
+
+### Fixed
+- `IntraListDiversity` metric computation in `cross_validate`
 
 ## [0.7.0] - 29.07.2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Debias` mechanism for classification, ranking and auc metrics. New parameter `is_debiased` to `calc_from_confusion_df`, `calc_per_user_from_confusion_df` methods of classification metrics, `calc_from_fitted`, `calc_per_user_from_fitted` methods of auc and rankning (`MAP`) metrics, `calc_from_merged`, `calc_per_user_from_merged` methods of ranking (`NDCG`, `MRR`) metrics. ([#152](https://github.com/MobileTeleSystems/RecTools/pull/152))
-- `filter_on_interactions_df_row_indexes` method of `Dataset`
+- `filter_on_interactions_df_row_indexes` method of `Dataset` ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
 
 ### Removed
-- [Breaking] `assume_external_ids` parameter in `recommend` and `recommend_to_items` model methods 
+- [Breaking] `assume_external_ids` parameter in `recommend` and `recommend_to_items` model methods ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
+
 
 ### Fixed
-- `IntraListDiversity` metric computation in `cross_validate`
+- `IntraListDiversity` metric computation in `cross_validate` ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
+
 
 ## [0.7.0] - 29.07.2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `display()` method in `MetricsApp` ([#169](https://github.com/MobileTeleSystems/RecTools/pull/169))
 - `IntraListDiversity` metric computation in `cross_validate` ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
+- Allow warp-kos loss for LightFMWrapperModel ([#175](https://github.com/MobileTeleSystems/RecTools/pull/175))
 
 ### Removed
 - [Breaking] `assume_external_ids` parameter in `recommend` and `recommend_to_items` model methods ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
-
-
-### Fixed
-- `IntraListDiversity` metric computation in `cross_validate` ([#177](https://github.com/MobileTeleSystems/RecTools/pull/177))
-
-
-### Fixed
-- Allow warp-kos loss for LightFMWrapperModel ([#175](https://github.com/MobileTeleSystems/RecTools/pull/175))
 
 ## [0.7.0] - 29.07.2024
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ RecTools is on PyPI, so you can use `pip` to install it.
 ```
 pip install rectools
 ```
-The default version doesn't contain all the dependencies, because some of them are needed only for specific funcitonality. Available user extensions are the following:
+The default version doesn't contain all the dependencies, because some of them are needed only for specific functionality. Available user extensions are the following:
 
 - `lightfm`: adds wrapper for LightFM model,
 - `torch`: adds models based on neural nets,

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ RecTools is on PyPI, so you can use `pip` to install it.
 ```
 pip install rectools
 ```
-The default version doesn't contain all the dependencies, because some of them are needed only for specific models. Available user extensions are the following:
+The default version doesn't contain all the dependencies, because some of them are needed only for specific funcitonality. Available user extensions are the following:
 
 - `lightfm`: adds wrapper for LightFM model,
 - `torch`: adds models based on neural nets,
@@ -125,7 +125,7 @@ See [recommender baselines extended tutorial](https://github.com/MobileTeleSyste
 [Contributing guide](CONTRIBUTING.rst)
 
 To install all requirements
-- you must have `python3` and `poetry==1.4.0` installed
+- you must have `python3` and `poetry` installed
 - make sure you have no active virtual environments (deactivate conda `base` if applicable)
 - run
 ```

--- a/rectools/dataset/dataset.py
+++ b/rectools/dataset/dataset.py
@@ -274,10 +274,10 @@ class Dataset:
             Filtered dataset that has only selected interactions, new ids mapping and processed features.
         """
         interactions_df = self.get_raw_interactions() if keep_external_ids else self.interactions.df
-        train = interactions_df.iloc[row_indexes_to_keep]
-        user_id_map = IdMap.from_values(train[Columns.User].values)  # 2x internal
-        item_id_map = IdMap.from_values(train[Columns.Item].values)  # 2x internal
-        interactions_train = Interactions.from_raw(train, user_id_map, item_id_map)  # 2x internal
+        interactions_df = interactions_df.iloc[row_indexes_to_keep]
+        user_id_map = IdMap.from_values(interactions_df[Columns.User].values)  # 2x internal
+        item_id_map = IdMap.from_values(interactions_df[Columns.Item].values)  # 2x internal
+        interactions = Interactions.from_raw(interactions_df, user_id_map, item_id_map)  # 2x internal
 
         def _handle_features(
             features: tp.Optional[Features], target_id_map: IdMap, dataset_id_map: IdMap
@@ -305,7 +305,7 @@ class Dataset:
         filtered_dataset = Dataset(
             user_id_map=user_id_map,
             item_id_map=item_id_map,
-            interactions=interactions_train,
+            interactions=interactions,
             user_features=user_features_new,
             item_features=item_features_new,
         )

--- a/rectools/dataset/dataset.py
+++ b/rectools/dataset/dataset.py
@@ -1,4 +1,4 @@
-#  Copyright 2022 MTS (Mobile Telesystems)
+#  Copyright 2022-2024 MTS (Mobile Telesystems)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/rectools/dataset/dataset.py
+++ b/rectools/dataset/dataset.py
@@ -273,11 +273,12 @@ class Dataset:
         Dataset
             Filtered dataset that has only selected interactions, new ids mapping and processed features.
         """
-        interactions_df = self.get_raw_interactions() if keep_external_ids else self.interactions.df
-        interactions_df = interactions_df.iloc[row_indexes_to_keep]
-        user_id_map = IdMap.from_values(interactions_df[Columns.User].values)  # 2x internal
-        item_id_map = IdMap.from_values(interactions_df[Columns.Item].values)  # 2x internal
-        interactions = Interactions.from_raw(interactions_df, user_id_map, item_id_map)  # 2x internal
+        interactions_df = self.interactions.df.loc[row_indexes_to_keep]
+
+        # 1x internal -> 2x internal
+        user_id_map = IdMap.from_values(interactions_df[Columns.User].values)
+        item_id_map = IdMap.from_values(interactions_df[Columns.Item].values)
+        interactions = Interactions.from_raw(interactions_df, user_id_map, item_id_map)
 
         def _handle_features(
             features: tp.Optional[Features], target_id_map: IdMap, dataset_id_map: IdMap
@@ -286,21 +287,19 @@ class Dataset:
                 return None, target_id_map
 
             if keep_features_for_removed_entities:
-                all_features_ids = np.arange(len(features))  # 1x internal
-                if keep_external_ids:
-                    all_features_ids = dataset_id_map.convert_to_external(all_features_ids)  # external
+                all_features_ids = np.arange(len(features))
                 target_id_map = target_id_map.add_ids(all_features_ids, raise_if_already_present=False)
 
-            needed_ids = target_id_map.get_external_sorted_by_internal()  # external or 1x internal
-            if keep_external_ids:
-                features = features.take(dataset_id_map.convert_to_internal(needed_ids))  # 2x internal
-            else:
-                features = features.take(needed_ids)  # 2x internal
-
+            needed_ids = target_id_map.get_external_sorted_by_internal()
+            features = features.take(needed_ids)
             return features, target_id_map
 
         user_features_new, user_id_map = _handle_features(self.user_features, user_id_map, self.user_id_map)
         item_features_new, item_id_map = _handle_features(self.item_features, item_id_map, self.item_id_map)
+
+        if keep_external_ids:  # external -> 2x internal
+            user_id_map = IdMap(self.user_id_map.convert_to_external(user_id_map.external_ids))
+            item_id_map = IdMap(self.item_id_map.convert_to_external(item_id_map.external_ids))
 
         filtered_dataset = Dataset(
             user_id_map=user_id_map,

--- a/rectools/dataset/dataset.py
+++ b/rectools/dataset/dataset.py
@@ -247,7 +247,7 @@ class Dataset:
         """
         return self.interactions.to_external(self.user_id_map, self.item_id_map, include_weight, include_datetime)
 
-    def filter_on_interactions_df_row_indexes(
+    def filter_interactions_df_rows(
         self,
         row_indexes_to_keep: np.ndarray,
         keep_external_ids: bool = True,
@@ -273,7 +273,7 @@ class Dataset:
         Dataset
             Filtered dataset that has only selected interactions, new ids mapping and processed features.
         """
-        interactions_df = self.interactions.df.loc[row_indexes_to_keep]
+        interactions_df = self.interactions.df.iloc[row_indexes_to_keep]
 
         # 1x internal -> 2x internal
         user_id_map = IdMap.from_values(interactions_df[Columns.User].values)

--- a/rectools/dataset/dataset.py
+++ b/rectools/dataset/dataset.py
@@ -247,7 +247,7 @@ class Dataset:
         """
         return self.interactions.to_external(self.user_id_map, self.item_id_map, include_weight, include_datetime)
 
-    def filter_interactions_df_rows(
+    def filter_interactions(
         self,
         row_indexes_to_keep: np.ndarray,
         keep_external_ids: bool = True,

--- a/rectools/model_selection/cross_validate.py
+++ b/rectools/model_selection/cross_validate.py
@@ -1,3 +1,17 @@
+#  Copyright 2023-2024 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import typing as tp
 
 from rectools.columns import Columns

--- a/rectools/model_selection/cross_validate.py
+++ b/rectools/model_selection/cross_validate.py
@@ -108,7 +108,7 @@ def cross_validate(  # pylint: disable=too-many-locals
     for train_ids, test_ids, split_info in split_iterator:
         split_infos.append(split_info)
 
-        fold_dataset = dataset.filter_interactions_df_rows(
+        fold_dataset = dataset.filter_interactions(
             row_indexes_to_keep=train_ids,
             keep_external_ids=True,
             keep_features_for_removed_entities=prefer_warm_inference_over_cold,

--- a/rectools/model_selection/cross_validate.py
+++ b/rectools/model_selection/cross_validate.py
@@ -1,69 +1,13 @@
-#  Copyright 2023-2024 MTS (Mobile Telesystems)
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 import typing as tp
 
-import numpy as np
-import pandas as pd
-
 from rectools.columns import Columns
-from rectools.dataset import Dataset, Features, IdMap, Interactions
+from rectools.dataset import Dataset
 from rectools.metrics import calc_metrics
 from rectools.metrics.base import MetricAtK
-from rectools.models.base import ModelBase
+from rectools.models.base import ErrorBehaviour, ModelBase
 from rectools.types import ExternalIds
 
 from .splitter import Splitter
-
-
-def _gen_2x_internal_ids_dataset(
-    interactions_internal_df: pd.DataFrame,
-    user_features: tp.Optional[Features],
-    item_features: tp.Optional[Features],
-    prefer_warm_inference_over_cold: bool,
-) -> Dataset:
-    """
-    Make new dataset based on given interactions and features from base dataset.
-    Assume that interactions dataframe contains internal ids.
-    Returned dataset contains 2nd level of internal ids.
-    """
-    user_id_map = IdMap.from_values(interactions_internal_df[Columns.User].values)  # 1x internal -> 2x internal
-    item_id_map = IdMap.from_values(interactions_internal_df[Columns.Item].values)  # 1x internal -> 2x internal
-    interactions_train = Interactions.from_raw(interactions_internal_df, user_id_map, item_id_map)  # 2x internal
-
-    def _handle_features(features: tp.Optional[Features], id_map: IdMap) -> tp.Tuple[tp.Optional[Features], IdMap]:
-        if features is None:
-            return None, id_map
-
-        if prefer_warm_inference_over_cold:
-            all_features_ids = np.arange(len(features))  # 1x internal
-            id_map = id_map.add_ids(all_features_ids, raise_if_already_present=False)
-
-        features = features.take(id_map.get_external_sorted_by_internal())  # 2x internal
-        return features, id_map
-
-    user_features_new, user_id_map = _handle_features(user_features, user_id_map)
-    item_features_new, item_id_map = _handle_features(item_features, item_id_map)
-
-    dataset = Dataset(
-        user_id_map=user_id_map,
-        item_id_map=item_id_map,
-        interactions=interactions_train,
-        user_features=user_features_new,
-        item_features=item_features_new,
-    )
-    return dataset
 
 
 def cross_validate(  # pylint: disable=too-many-locals
@@ -77,6 +21,7 @@ def cross_validate(  # pylint: disable=too-many-locals
     prefer_warm_inference_over_cold: bool = True,
     ref_models: tp.Optional[tp.List[str]] = None,
     validate_ref_models: bool = False,
+    on_unsupported_targets: ErrorBehaviour = "warn",
 ) -> tp.Dict[str, tp.Any]:
     """
     Run cross validation on multiple models with multiple metrics.
@@ -113,6 +58,15 @@ def cross_validate(  # pylint: disable=too-many-locals
     validate_ref_models : bool, default False
         If True include models specified in `ref_models` to all metrics calculations
         and receive their metrics from cross-validation.
+    on_unsupported_targets : Literal["raise", "warn", "ignore"], default "warn"
+        How to handle warm/cold target users when model doesn't support warm/cold inference.
+        Specify "warn" to filter with warning (default in `cross_validate`).
+        Specify "ignore" to filter unsupported targets without a warning.
+        It is highly recommended to pass `CoveredUsers` DQ metric to catch all models with
+        insufficient recommendations for each fold.
+        Specify "raise" to raise ValueError in case unsupported targets are passed. In cross-validation
+        this may cause unexpected errors for some of the complicated models.
+
 
     Returns
     -------
@@ -132,9 +86,7 @@ def cross_validate(  # pylint: disable=too-many-locals
             ]
         }
     """
-    interactions = dataset.interactions
-
-    split_iterator = splitter.split(interactions, collect_fold_stats=True)
+    split_iterator = splitter.split(dataset.interactions, collect_fold_stats=True)
 
     split_infos = []
     metrics_all = []
@@ -142,24 +94,15 @@ def cross_validate(  # pylint: disable=too-many-locals
     for train_ids, test_ids, split_info in split_iterator:
         split_infos.append(split_info)
 
-        # ### Prepare split data
-        interactions_df_train = interactions.df.iloc[train_ids]  # 1x internal
-        # We need to avoid fitting models on sparse matrices with all zero rows/columns =>
-        # => we need to create a fold dataset which contains only hot users and items for current training
-        fold_dataset = _gen_2x_internal_ids_dataset(
-            interactions_df_train, dataset.user_features, dataset.item_features, prefer_warm_inference_over_cold
+        fold_dataset = dataset.filter_on_interactions_df_row_indexes(
+            row_indexes_to_keep=train_ids,
+            keep_external_ids=True,
+            keep_features_for_removed_entities=prefer_warm_inference_over_cold,
         )
-
-        interactions_df_test = interactions.df.iloc[test_ids]  # 1x internal
-        test_users = interactions_df_test[Columns.User].unique()  # 1x internal
-        catalog = interactions_df_train[Columns.Item].unique()  # 1x internal
-
-        if items_to_recommend is not None:
-            item_ids_to_recommend = dataset.item_id_map.convert_to_internal(
-                items_to_recommend, strict=False
-            )  # 1x internal
-        else:
-            item_ids_to_recommend = None
+        interactions_df_test = dataset.get_raw_interactions().iloc[test_ids]
+        test_users = interactions_df_test[Columns.User].unique()
+        prev_interactions = fold_dataset.get_raw_interactions()
+        catalog = prev_interactions[Columns.Item].unique()
 
         # ### Train ref models if any
         ref_reco = {}
@@ -171,7 +114,8 @@ def cross_validate(  # pylint: disable=too-many-locals
                 dataset=fold_dataset,
                 k=k,
                 filter_viewed=filter_viewed,
-                items_to_recommend=item_ids_to_recommend,
+                items_to_recommend=items_to_recommend,
+                on_unsupported_targets=on_unsupported_targets,
             )
 
         # ### Generate recommendations and calc metrics
@@ -188,14 +132,15 @@ def cross_validate(  # pylint: disable=too-many-locals
                     dataset=fold_dataset,
                     k=k,
                     filter_viewed=filter_viewed,
-                    items_to_recommend=item_ids_to_recommend,
+                    items_to_recommend=items_to_recommend,
+                    on_unsupported_targets=on_unsupported_targets,
                 )
 
             metric_values = calc_metrics(
                 metrics,
                 reco=reco,
                 interactions=interactions_df_test,
-                prev_interactions=interactions_df_train,
+                prev_interactions=prev_interactions,
                 catalog=catalog,
                 ref_reco=ref_reco,
             )

--- a/rectools/model_selection/cross_validate.py
+++ b/rectools/model_selection/cross_validate.py
@@ -101,6 +101,7 @@ def cross_validate(  # pylint: disable=too-many-locals
         }
     """
     split_iterator = splitter.split(dataset.interactions, collect_fold_stats=True)
+    raw_interactions = dataset.get_raw_interactions()
 
     split_infos = []
     metrics_all = []
@@ -113,7 +114,7 @@ def cross_validate(  # pylint: disable=too-many-locals
             keep_external_ids=True,
             keep_features_for_removed_entities=prefer_warm_inference_over_cold,
         )
-        interactions_df_test = dataset.get_raw_interactions().iloc[test_ids]
+        interactions_df_test = raw_interactions.iloc[test_ids]
         test_users = interactions_df_test[Columns.User].unique()
         prev_interactions = fold_dataset.get_raw_interactions()
         catalog = prev_interactions[Columns.Item].unique()

--- a/rectools/model_selection/cross_validate.py
+++ b/rectools/model_selection/cross_validate.py
@@ -108,7 +108,7 @@ def cross_validate(  # pylint: disable=too-many-locals
     for train_ids, test_ids, split_info in split_iterator:
         split_infos.append(split_info)
 
-        fold_dataset = dataset.filter_on_interactions_df_row_indexes(
+        fold_dataset = dataset.filter_interactions_df_rows(
             row_indexes_to_keep=train_ids,
             keep_external_ids=True,
             keep_features_for_removed_entities=prefer_warm_inference_over_cold,

--- a/rectools/models/base.py
+++ b/rectools/models/base.py
@@ -73,16 +73,18 @@ class ModelBase:
     def _fit(self, dataset: Dataset, *args: tp.Any, **kwargs: tp.Any) -> None:
         raise NotImplementedError()
 
-    def _process_dataset_u2i(
+    def _custom_transform_dataset_u2i(
         self, dataset: Dataset, users: ExternalIds, on_unsupported_targets: ErrorBehaviour
     ) -> Dataset:
-        # This method could be overwritten for models that require specific logic
+        # This method should be overwritten for models that require dataset processing for u2i recommendations
+        # E.g.: interactions filtering or changing mapping of internal ids based on model specific logic
         return dataset
 
-    def _process_dataset_i2i(
+    def _custom_transform_dataset_i2i(
         self, dataset: Dataset, target_items: ExternalIds, on_unsupported_targets: ErrorBehaviour
     ) -> Dataset:
-        # This method could be overwritten for models that require specific logic
+        # This method should be overwritten for models that require dataset processing for i2i recommendations
+        # E.g.: interactions filtering or changing mapping of internal ids based on model specific logic
         return dataset
 
     def recommend(
@@ -152,7 +154,8 @@ class ModelBase:
         """
         self._check_is_fitted()
         self._check_k(k)
-        dataset = self._process_dataset_u2i(dataset, users, on_unsupported_targets)
+
+        dataset = self._custom_transform_dataset_u2i(dataset, users, on_unsupported_targets)
 
         sorted_item_ids_to_recommend = self._get_sorted_item_ids_to_recommend(items_to_recommend, dataset)
 
@@ -265,7 +268,7 @@ class ModelBase:
         self._check_is_fitted()
         self._check_k(k)
 
-        dataset = self._process_dataset_i2i(dataset, target_items, on_unsupported_targets)
+        dataset = self._custom_transform_dataset_i2i(dataset, target_items, on_unsupported_targets)
 
         sorted_item_ids_to_recommend = self._get_sorted_item_ids_to_recommend(items_to_recommend, dataset)
 

--- a/rectools/models/base.py
+++ b/rectools/models/base.py
@@ -1,4 +1,4 @@
-#  Copyright 2022 MTS (Mobile Telesystems)
+#  Copyright 2022-2024 MTS (Mobile Telesystems)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/rectools/models/base.py
+++ b/rectools/models/base.py
@@ -1,4 +1,4 @@
-#  Copyright 2022-2024 MTS (Mobile Telesystems)
+#  Copyright 2022 MTS (Mobile Telesystems)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,25 +15,27 @@
 """Base model."""
 
 import typing as tp
+import warnings
 
 import numpy as np
 import pandas as pd
 
-from rectools import AnyIds, Columns, InternalIds
+from rectools import Columns, ExternalIds, InternalIds
 from rectools.dataset import Dataset
 from rectools.dataset.identifiers import IdMap
 from rectools.exceptions import NotFittedError
-from rectools.types import AnyIdsArray, InternalIdsArray
+from rectools.types import ExternalIdsArray, InternalIdsArray
 
 T = tp.TypeVar("T", bound="ModelBase")
 ScoresArray = np.ndarray
 Scores = tp.Union[tp.Sequence[float], ScoresArray]
+ErrorBehaviour = tp.Literal["ignore", "warn", "raise"]
 
 InternalRecoTriplet = tp.Tuple[InternalIds, InternalIds, Scores]
-SemiInternalRecoTriplet = tp.Tuple[AnyIds, InternalIds, Scores]
-RecoTriplet = tp.Tuple[AnyIds, AnyIds, Scores]
+SemiInternalRecoTriplet = tp.Tuple[ExternalIds, InternalIds, Scores]
+ExternalRecoTriplet = tp.Tuple[ExternalIds, ExternalIds, Scores]
 
-RecoTriplet_T = tp.TypeVar("RecoTriplet_T", InternalRecoTriplet, SemiInternalRecoTriplet, RecoTriplet)
+RecoTriplet_T = tp.TypeVar("RecoTriplet_T", InternalRecoTriplet, SemiInternalRecoTriplet, ExternalRecoTriplet)
 
 
 class ModelBase:
@@ -71,15 +73,27 @@ class ModelBase:
     def _fit(self, dataset: Dataset, *args: tp.Any, **kwargs: tp.Any) -> None:
         raise NotImplementedError()
 
+    def _process_dataset_u2i(
+        self, dataset: Dataset, users: ExternalIds, on_unsupported_targets: ErrorBehaviour
+    ) -> Dataset:
+        # This method could be overwritten for models that require specific logic
+        return dataset
+
+    def _process_dataset_i2i(
+        self, dataset: Dataset, target_items: ExternalIds, on_unsupported_targets: ErrorBehaviour
+    ) -> Dataset:
+        # This method could be overwritten for models that require specific logic
+        return dataset
+
     def recommend(
         self,
-        users: AnyIds,
+        users: ExternalIds,
         dataset: Dataset,
         k: int,
         filter_viewed: bool,
-        items_to_recommend: tp.Optional[AnyIds] = None,
+        items_to_recommend: tp.Optional[ExternalIds] = None,
         add_rank_col: bool = True,
-        assume_external_ids: bool = True,
+        on_unsupported_targets: ErrorBehaviour = "raise",
     ) -> pd.DataFrame:
         r"""
         Recommend items for users.
@@ -89,9 +103,7 @@ class ModelBase:
         Parameters
         ----------
         users : array-like
-            Array of user ids to recommend for.
-            User ids are supposed to be external if `assume_external_ids` is ``True`` (default).
-            Internal otherwise.
+            Array of user ids to recommend for. User ids are supposed to be external
         dataset : Dataset
             Dataset with input data.
             Usually it's the same dataset that was used to fit model.
@@ -105,18 +117,18 @@ class ModelBase:
             Whitelist of item ids.
             If given, only these items will be used for recommendations.
             Otherwise all items from dataset will be used.
-            Item ids are supposed to be external if `assume_external_ids` is `True`` (default).
-            Internal otherwise.
+            Item ids are supposed to be external.
         add_rank_col : bool, default True
             Whether to add rank column to recommendations.
             If True column `Columns.Rank` will be added.
             This column contain integers from 1 to ``number of user recommendations``.
             In any case recommendations are sorted per rank for every user.
             The lesser the rank the more recommendation is relevant.
-        assume_external_ids : bool, default True
-            When ``True`` all input user and item ids are supposed to be external.
-            Ids in returning recommendations table will be external as well.
-            Internal otherwise. Works faster with ``False``.
+        on_unsupported_targets : Literal["raise", "warn", "ignore"], default "raise"
+            How to handle warm/cold target users when model doesn't support warm/cold inference.
+            Specify "raise" to raise ValueError in case unsupported targets are passed (default).
+            Specify "ignore" to filter unsupported targets.
+            Specify "warn" to filter with warning.
 
         Returns
         -------
@@ -135,24 +147,24 @@ class ModelBase:
         TypeError, ValueError
             If arguments have inappropriate type or value
         ValueError
-            If some of given users are warm/cold and model doesn't support such type of users.
+            If some of given users are warm/cold and model doesn't support such type of users and
+            `on_unsupported_targets` is set to "raise".
         """
         self._check_is_fitted()
         self._check_k(k)
+        dataset = self._process_dataset_u2i(dataset, users, on_unsupported_targets)
 
-        sorted_item_ids_to_recommend = self._get_sorted_item_ids_to_recommend(
-            items_to_recommend, dataset, assume_external_ids
-        )
+        sorted_item_ids_to_recommend = self._get_sorted_item_ids_to_recommend(items_to_recommend, dataset)
 
-        # Here for hot and warm we get internal ids, for cold we keep given ids
+        # Here for hot and warm we get internal ids, for cold we keep external ids
         hot_user_ids, warm_user_ids, cold_user_ids = self._split_targets_by_hot_warm_cold(
             users,
-            dataset.user_id_map,
-            dataset.n_hot_users,
-            assume_external_ids,
+            dataset,
             "user",
         )
-        self._check_targets_are_valid(hot_user_ids, warm_user_ids, cold_user_ids, "user")
+        hot_user_ids, warm_user_ids, cold_user_ids = self._check_targets_are_valid(
+            hot_user_ids, warm_user_ids, cold_user_ids, "user", on_unsupported_targets
+        )
 
         reco_hot = self._init_internal_reco_triplet()
         reco_warm = self._init_internal_reco_triplet()
@@ -175,12 +187,10 @@ class ModelBase:
         reco_warm = self._adjust_reco_types(reco_warm)
         reco_cold = self._adjust_reco_types(reco_cold, target_type=dataset.user_id_map.external_dtype)
 
-        if assume_external_ids:
-            reco_hot_final = self._reco_to_external(reco_hot, dataset.user_id_map, dataset.item_id_map)
-            reco_warm_final = self._reco_to_external(reco_warm, dataset.user_id_map, dataset.item_id_map)
-            reco_cold_final = self._reco_items_to_external(reco_cold, dataset.item_id_map)
-        else:
-            reco_hot_final, reco_warm_final, reco_cold_final = reco_hot, reco_warm, reco_cold
+        reco_hot_final = self._reco_to_external(reco_hot, dataset.user_id_map, dataset.item_id_map)
+        reco_warm_final = self._reco_to_external(reco_warm, dataset.user_id_map, dataset.item_id_map)
+        reco_cold_final = self._reco_items_to_external(reco_cold, dataset.item_id_map)
+
         del reco_hot, reco_warm, reco_cold
 
         reco_all = self._concat_reco((reco_hot_final, reco_warm_final, reco_cold_final))
@@ -190,13 +200,13 @@ class ModelBase:
 
     def recommend_to_items(  # pylint: disable=too-many-branches
         self,
-        target_items: AnyIds,
+        target_items: ExternalIds,
         dataset: Dataset,
         k: int,
         filter_itself: bool = True,
-        items_to_recommend: tp.Optional[AnyIds] = None,
+        items_to_recommend: tp.Optional[ExternalIds] = None,
         add_rank_col: bool = True,
-        assume_external_ids: bool = True,
+        on_unsupported_targets: ErrorBehaviour = "raise",
     ) -> pd.DataFrame:
         """
         Recommend items for target items.
@@ -206,9 +216,7 @@ class ModelBase:
         Parameters
         ----------
         target_items : array-like
-            Array of item ids to recommend for.
-            Item ids are supposed to be external if `assume_external_ids` is `True`` (default).
-            Internal otherwise.
+            Array of item ids to recommend for. Item ids are supposed to be external.
         dataset : Dataset
             Dataset with input data.
             Usually it's the same dataset that was used to fit model.
@@ -221,18 +229,18 @@ class ModelBase:
             Whitelist of item ids.
             If given, only these items will be used for recommendations.
             Otherwise all items from dataset will be used.
-            Item ids are supposed to be external if `assume_external_ids` is `True`` (default).
-            Internal otherwise.
+            Item ids are supposed to be external
         add_rank_col : bool, default True
              Whether to add rank column to recommendations.
              If True column `Columns.Rank` will be added.
              This column contain integers from 1 to ``number of item recommendations``.
              In any case recommendations are sorted per rank for every target item.
              Less rank means more relevant recommendation.
-        assume_external_ids : bool, default True
-            When ``True`` all input item ids are supposed to be external.
-            Ids in returning recommendations table will be external as well.
-            Internal otherwise. Works faster with ``False``.
+        on_unsupported_targets : Literal["raise", "warn", "ignore"], default "raise"
+            How to handle warm/cold target users when model doesn't support warm/cold inference.
+            Specify "raise" to raise ValueError in case unsupported targets are passed (default).
+            Specify "ignore" to filter unsupported targets.
+            Specify "warn" to filter with warning.
 
         Returns
         -------
@@ -250,25 +258,26 @@ class ModelBase:
             If called for not fitted model.
         TypeError, ValueError
             If arguments have inappropriate type or value
-        KeyError
-            If some of given target items are not in `dataset.item_id_map`
+        ValueError
+            If some of given users are warm/cold and model doesn't support such type of users and
+            `on_unsupported_targets` is set to "raise".
         """
         self._check_is_fitted()
         self._check_k(k)
 
-        sorted_item_ids_to_recommend = self._get_sorted_item_ids_to_recommend(
-            items_to_recommend, dataset, assume_external_ids
-        )
+        dataset = self._process_dataset_i2i(dataset, target_items, on_unsupported_targets)
 
-        # Here for hot and warm we get internal ids, for cold we keep given ids
+        sorted_item_ids_to_recommend = self._get_sorted_item_ids_to_recommend(items_to_recommend, dataset)
+
+        # Here for hot and warm we get internal ids, for cold we keep external ids
         hot_target_ids, warm_target_ids, cold_target_ids = self._split_targets_by_hot_warm_cold(
             target_items,
-            dataset.item_id_map,
-            dataset.n_hot_items,
-            assume_external_ids,
+            dataset,
             "item",
         )
-        self._check_targets_are_valid(hot_target_ids, warm_target_ids, cold_target_ids, "item")
+        hot_target_ids, warm_target_ids, cold_target_ids = self._check_targets_are_valid(
+            hot_target_ids, warm_target_ids, cold_target_ids, "item", on_unsupported_targets
+        )
 
         requested_k = k + 1 if filter_itself else k
 
@@ -301,12 +310,9 @@ class ModelBase:
             reco_warm = self._filter_item_itself_from_i2i_reco(reco_warm, k)
             # We don't filter cold reco since we never recommend cold items
 
-        if assume_external_ids:
-            reco_hot_final = self._reco_to_external(reco_hot, dataset.item_id_map, dataset.item_id_map)
-            reco_warm_final = self._reco_to_external(reco_warm, dataset.item_id_map, dataset.item_id_map)
-            reco_cold_final = self._reco_items_to_external(reco_cold, dataset.item_id_map)
-        else:
-            reco_hot_final, reco_warm_final, reco_cold_final = reco_hot, reco_warm, reco_cold
+        reco_hot_final = self._reco_to_external(reco_hot, dataset.item_id_map, dataset.item_id_map)
+        reco_warm_final = self._reco_to_external(reco_warm, dataset.item_id_map, dataset.item_id_map)
+        reco_cold_final = self._reco_items_to_external(reco_cold, dataset.item_id_map)
         del reco_hot, reco_warm, reco_cold
 
         reco_all = self._concat_reco((reco_hot_final, reco_warm_final, reco_cold_final))
@@ -333,42 +339,35 @@ class ModelBase:
 
     @classmethod
     def _get_sorted_item_ids_to_recommend(
-        cls, items_to_recommend: tp.Optional[AnyIds], dataset: Dataset, assume_external_ids: bool
+        cls, items_to_recommend: tp.Optional[ExternalIds], dataset: Dataset
     ) -> tp.Optional[InternalIdsArray]:
         if items_to_recommend is None:
             return None
 
-        if assume_external_ids:
-            item_ids_to_recommend = dataset.item_id_map.convert_to_internal(items_to_recommend, strict=False)
-        else:
-            item_ids_to_recommend = cls._ensure_internal_ids_valid(items_to_recommend)
+        internal_ids_to_recommend = dataset.item_id_map.convert_to_internal(items_to_recommend, strict=False)
 
-        sorted_item_ids_to_recommend = np.unique(item_ids_to_recommend)
-        return sorted_item_ids_to_recommend
+        return np.unique(internal_ids_to_recommend)
 
     @classmethod
     def _split_targets_by_hot_warm_cold(
         cls,
-        targets: AnyIds,  # users for U2I or target items for I2I
-        id_map: IdMap,
-        n_hot: int,
-        assume_external_ids: bool,
+        targets: ExternalIds,  # users for U2I or target items for I2I
+        dataset: Dataset,
         entity: tp.Literal["user", "item"],
-    ) -> tp.Tuple[InternalIdsArray, InternalIdsArray, AnyIdsArray]:
-        if assume_external_ids:
-            known_ids, cold_ids = id_map.convert_to_internal(targets, strict=False, return_missing=True)
-            try:
-                cold_ids = cold_ids.astype(id_map.external_dtype)
-            except ValueError:
-                raise TypeError(
-                    f"Given {entity} ids must be convertible to the "
-                    f"{entity}_id` type in dataset ({id_map.external_dtype})"
-                )
+    ) -> tp.Tuple[InternalIdsArray, InternalIdsArray, ExternalIdsArray]:
+        if entity == "user":
+            id_map, n_hot = dataset.user_id_map, dataset.n_hot_users
         else:
-            target_ids = cls._ensure_internal_ids_valid(targets)
-            known_mask = target_ids < id_map.size
-            known_ids = target_ids[known_mask]
-            cold_ids = target_ids[~known_mask]
+            id_map, n_hot = dataset.item_id_map, dataset.n_hot_items
+
+        known_ids, cold_ids = id_map.convert_to_internal(targets, strict=False, return_missing=True)
+        try:
+            cold_ids = cold_ids.astype(id_map.external_dtype)
+        except ValueError:
+            raise TypeError(
+                f"Given {entity} ids must be convertible to the "
+                f"{entity}_id` type in dataset ({id_map.external_dtype})"
+            )
 
         hot_mask = known_ids < n_hot
         hot_ids = known_ids[hot_mask]
@@ -380,29 +379,32 @@ class ModelBase:
         cls,
         hot_targets: InternalIdsArray,
         warm_targets: InternalIdsArray,
-        cold_targets: AnyIdsArray,
+        cold_targets: ExternalIdsArray,
         entity: tp.Literal["user", "item"],
-    ) -> None:
+        on_unsupported_targets: ErrorBehaviour,
+    ) -> tp.Tuple[InternalIdsArray, InternalIdsArray, ExternalIdsArray]:
         if warm_targets.size > 0 and not cls.recommends_for_warm and not cls.recommends_for_cold:
-            raise ValueError(
-                f"Model `{cls}` doesn't support recommendations for warm and cold {entity}s, "
-                f"but some of given {entity}s are warm: they are not in the interactions"
-            )
+            explanation = f"""
+                Model `{cls}` doesn't support recommendations for warm and cold {entity}s,
+                but some of given {entity}s are warm: they are not in the interactions
+            """
+            if on_unsupported_targets == "warn":
+                warnings.warn(explanation)
+            elif on_unsupported_targets == "raise":
+                raise ValueError(explanation)
+            warm_targets = np.asarray([])
 
         if cold_targets.size > 0 and not cls.recommends_for_cold:
-            raise ValueError(
-                f"Model `{cls}` doesn't support recommendations for cold {entity}s, "
-                f"but some of given {entity}s are cold: they are not in the `dataset.{entity}_id_map`"
-            )
-
-    @classmethod
-    def _ensure_internal_ids_valid(cls, internal_ids: AnyIds) -> InternalIdsArray:
-        ids = np.asarray(internal_ids)
-        if not np.issubdtype(ids.dtype, np.integer):
-            raise TypeError("Internal ids are always integer")
-        if ids.min() < 0:
-            raise ValueError("Internal ids should be non-negative integers")
-        return ids
+            explanation = f"""
+                Model `{cls}` doesn't support recommendations for cold {entity}s,
+                but some of given {entity}s are cold: they are not in the `dataset.{entity}_id_map`
+            """
+            if on_unsupported_targets == "warn":
+                warnings.warn(explanation)
+            elif on_unsupported_targets == "raise":
+                raise ValueError(explanation)
+            cold_targets = np.asarray([])
+        return hot_targets, warm_targets, cold_targets
 
     @classmethod
     def _adjust_reco_types(cls, reco: RecoTriplet_T, target_type: tp.Type = np.int64) -> RecoTriplet_T:
@@ -424,27 +426,29 @@ class ModelBase:
         return df_reco["tid"].values, df_reco["iid"].values, df_reco["score"].values
 
     @classmethod
-    def _reco_to_external(cls, reco: InternalRecoTriplet, target_id_map: IdMap, item_id_map: IdMap) -> RecoTriplet:
+    def _reco_to_external(
+        cls, reco: InternalRecoTriplet, target_id_map: IdMap, item_id_map: IdMap
+    ) -> ExternalRecoTriplet:
         target_ids, item_ids, scores = reco
         target_ids = target_id_map.convert_to_external(target_ids)
         item_ids = item_id_map.convert_to_external(item_ids)
         return target_ids, item_ids, scores
 
     @classmethod
-    def _reco_items_to_external(cls, reco: SemiInternalRecoTriplet, item_id_map: IdMap) -> RecoTriplet:
+    def _reco_items_to_external(cls, reco: SemiInternalRecoTriplet, item_id_map: IdMap) -> ExternalRecoTriplet:
         target_ids, item_ids, scores = reco
         item_ids = item_id_map.convert_to_external(item_ids)
         return target_ids, item_ids, scores
 
     @classmethod
-    def _concat_reco(cls, parts: tp.Sequence[RecoTriplet]) -> RecoTriplet:
+    def _concat_reco(cls, parts: tp.Sequence[RecoTriplet_T]) -> RecoTriplet_T:
         targets = np.concatenate([part[0] for part in parts])
         items = np.concatenate([part[1] for part in parts])
         scores = np.concatenate([part[2] for part in parts])
         return targets, items, scores
 
     @classmethod
-    def _make_reco_table(cls, reco: RecoTriplet, target_col: str, add_rank_col: bool) -> pd.DataFrame:
+    def _make_reco_table(cls, reco: ExternalRecoTriplet, target_col: str, add_rank_col: bool) -> pd.DataFrame:
         target_ids, item_ids, scores = reco
         df = pd.DataFrame(
             {
@@ -461,7 +465,7 @@ class ModelBase:
 
     def _recommend_cold(
         self,
-        target_ids: AnyIdsArray,
+        target_ids: ExternalIdsArray,
         dataset: Dataset,
         k: int,
         sorted_item_ids_to_recommend: tp.Optional[InternalIdsArray],
@@ -515,7 +519,7 @@ class FixedColdRecoModelMixin:
 
     def _recommend_cold(
         self,
-        target_ids: AnyIdsArray,
+        target_ids: ExternalIdsArray,
         dataset: Dataset,
         k: int,
         sorted_item_ids_to_recommend: tp.Optional[InternalIdsArray],

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -340,7 +340,7 @@ class TestDataset:
         "keep_external_ids, expected_external_item_ids, expected_external_user_ids",
         ((True, np.array([10, 30, 20]), np.array([10, 14, 12])), (False, np.array([0, 2, 1]), np.array([0, 4, 2]))),
     )
-    def test_filter_dataset_on_interactions_df_row_indexes_without_features(
+    def test_filter_dataset_interactions_df_rows_without_features(
         self,
         dataset_to_filter: Dataset,
         keep_features_for_removed_entities: bool,
@@ -349,7 +349,7 @@ class TestDataset:
         expected_external_user_ids: np.ndarray,
     ) -> None:
         rows_to_keep = np.arange(4)
-        filtered_dataset = dataset_to_filter.filter_on_interactions_df_row_indexes(
+        filtered_dataset = dataset_to_filter.filter_interactions_df_rows(
             rows_to_keep,
             keep_external_ids=keep_external_ids,
             keep_features_for_removed_entities=keep_features_for_removed_entities,
@@ -378,7 +378,7 @@ class TestDataset:
             (False, True, np.array([0, 2, 1, 3, 4]), np.array([0, 4, 2, 1, 3])),
         ),
     )
-    def test_filter_dataset_on_interactions_df_row_indexes_with_features(
+    def test_filter_dataset_interactions_df_rows_with_features(
         self,
         dataset_with_features_to_filter: Dataset,
         keep_features_for_removed_entities: bool,
@@ -387,7 +387,7 @@ class TestDataset:
         expected_external_user_ids: np.ndarray,
     ) -> None:
         rows_to_keep = np.arange(4)
-        filtered_dataset = dataset_with_features_to_filter.filter_on_interactions_df_row_indexes(
+        filtered_dataset = dataset_with_features_to_filter.filter_interactions_df_rows(
             rows_to_keep,
             keep_external_ids=keep_external_ids,
             keep_features_for_removed_entities=keep_features_for_removed_entities,

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,4 +1,4 @@
-#  Copyright 2022 MTS (Mobile Telesystems)
+# Copyright 2022-2024 MTS (Mobile Telesystems)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -349,7 +349,7 @@ class TestDataset:
         expected_external_user_ids: np.ndarray,
     ) -> None:
         rows_to_keep = np.arange(4)
-        filtered_dataset = dataset_to_filter.filter_interactions_df_rows(
+        filtered_dataset = dataset_to_filter.filter_interactions(
             rows_to_keep,
             keep_external_ids=keep_external_ids,
             keep_features_for_removed_entities=keep_features_for_removed_entities,
@@ -387,7 +387,7 @@ class TestDataset:
         expected_external_user_ids: np.ndarray,
     ) -> None:
         rows_to_keep = np.arange(4)
-        filtered_dataset = dataset_with_features_to_filter.filter_interactions_df_rows(
+        filtered_dataset = dataset_with_features_to_filter.filter_interactions(
             rows_to_keep,
             keep_external_ids=keep_external_ids,
             keep_features_for_removed_entities=keep_features_for_removed_entities,

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 MTS (Mobile Telesystems)
+#  Copyright 2022-2024 MTS (Mobile Telesystems)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/model_selection/test_cross_validate.py
+++ b/tests/model_selection/test_cross_validate.py
@@ -1,115 +1,20 @@
-#  Copyright 2023-2024 MTS (Mobile Telesystems)
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 # pylint: disable=attribute-defined-outside-init
 
 import typing as tp
 
-import numpy as np
 import pandas as pd
 import pytest
 from implicit.als import AlternatingLeastSquares
-from scipy import sparse
 
 from rectools import Columns, ExternalIds
-from rectools.dataset import Dataset, DenseFeatures, SparseFeatures
+from rectools.dataset import Dataset
 from rectools.metrics import Intersection, Precision, Recall
 from rectools.metrics.base import MetricAtK
 from rectools.model_selection import LastNSplitter, cross_validate
-from rectools.model_selection.cross_validate import _gen_2x_internal_ids_dataset
-from rectools.models import ImplicitALSWrapperModel, PopularInCategoryModel, PopularModel, RandomModel
+from rectools.models import ImplicitALSWrapperModel, PopularModel, RandomModel
 from rectools.models.base import ModelBase
-from tests.testing_utils import assert_sparse_matrix_equal
 
 a = pytest.approx
-
-
-class TestGen2xInternalIdsDataset:
-    def setup_method(self) -> None:
-        self.interactions_internal_df = pd.DataFrame(
-            [
-                [0, 0, 1, 101],
-                [0, 1, 1, 102],
-                [0, 0, 1, 103],
-                [3, 0, 1, 101],
-                [3, 2, 1, 102],
-            ],
-            columns=Columns.Interactions,
-        ).astype({Columns.Datetime: "datetime64[ns]", Columns.Weight: float})
-
-        self.expected_interactions_2x_internal_df = pd.DataFrame(
-            [
-                [0, 0, 1, 101],
-                [0, 1, 1, 102],
-                [0, 0, 1, 103],
-                [1, 0, 1, 101],
-                [1, 2, 1, 102],
-            ],
-            columns=Columns.Interactions,
-        ).astype({Columns.Datetime: "datetime64[ns]", Columns.Weight: float})
-
-    @pytest.mark.parametrize("prefer_warm_inference_over_cold", (True, False))
-    def test_without_features(self, prefer_warm_inference_over_cold: bool) -> None:
-        dataset = _gen_2x_internal_ids_dataset(
-            self.interactions_internal_df, None, None, prefer_warm_inference_over_cold
-        )
-
-        np.testing.assert_equal(dataset.user_id_map.external_ids, np.array([0, 3]))
-        np.testing.assert_equal(dataset.item_id_map.external_ids, np.array([0, 1, 2]))
-        pd.testing.assert_frame_equal(dataset.interactions.df, self.expected_interactions_2x_internal_df)
-        assert dataset.user_features is None
-        assert dataset.item_features is None
-
-    @pytest.mark.parametrize(
-        "prefer_warm_inference_over_cold, expected_user_ids, expected_item_ids",
-        (
-            (False, [0, 3], [0, 1, 2]),
-            (True, [0, 3, 1, 2], [0, 1, 2, 3]),
-        ),
-    )
-    def test_with_features(
-        self, prefer_warm_inference_over_cold: bool, expected_user_ids: tp.List[int], expected_item_ids: tp.List[int]
-    ) -> None:
-        user_features = DenseFeatures(
-            values=np.array([[1, 10], [2, 20], [3, 30], [4, 40]]),
-            names=("f1", "f2"),
-        )
-        item_features = SparseFeatures(
-            values=sparse.csr_matrix(
-                [
-                    [3.2, 0, 1],
-                    [2.4, 2, 0],
-                    [0.0, 0, 1],
-                    [1.0, 5, 1],
-                ],
-            ),
-            names=(("f1", None), ("f2", 100), ("f2", 200)),
-        )
-
-        dataset = _gen_2x_internal_ids_dataset(
-            self.interactions_internal_df, user_features, item_features, prefer_warm_inference_over_cold
-        )
-
-        np.testing.assert_equal(dataset.user_id_map.external_ids, np.array(expected_user_ids))
-        np.testing.assert_equal(dataset.item_id_map.external_ids, np.array(expected_item_ids))
-        pd.testing.assert_frame_equal(dataset.interactions.df, self.expected_interactions_2x_internal_df)
-
-        assert dataset.user_features is not None and dataset.item_features is not None  # for mypy
-        np.testing.assert_equal(dataset.user_features.values, user_features.values[expected_user_ids])
-        assert dataset.user_features.names == user_features.names
-        assert_sparse_matrix_equal(dataset.item_features.values, item_features.values[expected_item_ids])
-        assert dataset.item_features.names == item_features.names
 
 
 class TestCrossValidate:
@@ -146,7 +51,6 @@ class TestCrossValidate:
                 [14, "f2", 1],
                 [11, "f1", "y"],
                 [11, "f2", 2],
-                [12, "f1", "y"],
             ],
             columns=["id", "feature", "value"],
         )
@@ -248,7 +152,6 @@ class TestCrossValidate:
 
         models: tp.Dict[str, ModelBase] = {
             "als": ImplicitALSWrapperModel(AlternatingLeastSquares(factors=2, iterations=2, random_state=42)),
-            "pop_in_cat": PopularInCategoryModel(category_feature="f1", n_categories=2),
         }
 
         actual = cross_validate(
@@ -284,9 +187,7 @@ class TestCrossValidate:
             ],
             "metrics": [
                 {"model": "als", "i_split": 0, "precision@2": 0.5, "recall@1": 0.0},
-                {"model": "pop_in_cat", "i_split": 0, "precision@2": 0.5, "recall@1": 0.5},
-                {"model": "als", "i_split": 1, "precision@2": 0.375, "recall@1": 0.0},
-                {"model": "pop_in_cat", "i_split": 1, "precision@2": 0.375, "recall@1": 0.25},
+                {"model": "als", "i_split": 1, "precision@2": 0.375, "recall@1": 0.25},
             ],
         }
 

--- a/tests/model_selection/test_cross_validate.py
+++ b/tests/model_selection/test_cross_validate.py
@@ -1,3 +1,17 @@
+#  Copyright 2023-2024 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 # pylint: disable=attribute-defined-outside-init
 
 import typing as tp

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -342,20 +342,26 @@ class TestHotWarmCold:
     @pytest.mark.parametrize("dataset_key", ("no_features", "with_features"))
     @pytest.mark.parametrize("kind", ("u2i", "i2i"))
     @pytest.mark.parametrize("model_key", ("hot", "hot_warm"))
-    def test_not_cold_models_with_cold_targets(self, dataset_key: str, kind: str, model_key: str) -> None:
+    def test_not_cold_models_with_cold_targets_raise(self, dataset_key: str, kind: str, model_key: str) -> None:
         targets = self.colds[kind] + self.hots[kind]
-
-        # raise
         with pytest.raises(ValueError, match="doesn't support recommendations for cold"):
             self._get_reco(targets, model_key, dataset_key, kind, on_unsupported_targets="raise")
 
-        # ignore
+    @pytest.mark.parametrize("dataset_key", ("no_features", "with_features"))
+    @pytest.mark.parametrize("kind", ("u2i", "i2i"))
+    @pytest.mark.parametrize("model_key", ("hot", "hot_warm"))
+    def test_not_cold_models_with_cold_targets_ignore(self, dataset_key: str, kind: str, model_key: str) -> None:
+        targets = self.colds[kind] + self.hots[kind]
         actual = self._get_reco(targets, model_key, dataset_key, kind, on_unsupported_targets="ignore")
         expected_targets = self.hots[kind]
         expected = self._get_reco(expected_targets, model_key, dataset_key, kind)
         pd.testing.assert_frame_equal(actual, expected)
 
-        # warn
+    @pytest.mark.parametrize("dataset_key", ("no_features", "with_features"))
+    @pytest.mark.parametrize("kind", ("u2i", "i2i"))
+    @pytest.mark.parametrize("model_key", ("hot", "hot_warm"))
+    def test_not_cold_models_with_cold_targets_warn(self, dataset_key: str, kind: str, model_key: str) -> None:
+        targets = self.colds[kind] + self.hots[kind]
         with warnings.catch_warnings(record=True) as w:
             self._get_reco(targets, model_key, dataset_key, kind, on_unsupported_targets="warn")
             assert len(w) == 1
@@ -364,12 +370,14 @@ class TestHotWarmCold:
             assert "warm" not in str(w[-1].message)
 
     @pytest.mark.parametrize("kind", ("u2i", "i2i"))
-    def test_warm_only_model_with_warm_targets_without_features(self, kind: str) -> None:
+    def test_warm_only_model_with_warm_targets_without_features_raise(self, kind: str) -> None:
         targets = self.warms[kind] + self.hots[kind]
-
-        # raise
         with pytest.raises(ValueError, match="doesn't support recommendations for cold"):
             self._get_reco(targets, "hot_warm", "no_features", kind, on_unsupported_targets="raise")
+
+    @pytest.mark.parametrize("kind", ("u2i", "i2i"))
+    def test_warm_only_model_with_warm_targets_without_features_ignore(self, kind: str) -> None:
+        targets = self.warms[kind] + self.hots[kind]
 
         # ignore
         actual = self._get_reco(targets, "hot_warm", "no_features", kind, on_unsupported_targets="ignore")
@@ -377,7 +385,9 @@ class TestHotWarmCold:
         expected = self._get_reco(expected_targets, "hot_warm", "no_features", kind)
         pd.testing.assert_frame_equal(actual, expected)
 
-        # warn
+    @pytest.mark.parametrize("kind", ("u2i", "i2i"))
+    def test_warm_only_model_with_warm_targets_without_features_warn(self, kind: str) -> None:
+        targets = self.warms[kind] + self.hots[kind]
         with warnings.catch_warnings(record=True) as w:
             self._get_reco(targets, "hot_warm", "no_features", kind, on_unsupported_targets="warn")
             assert len(w) == 1
@@ -386,20 +396,22 @@ class TestHotWarmCold:
             assert "warm" not in str(w[-1].message)
 
     @pytest.mark.parametrize("kind", ("u2i", "i2i"))
-    def test_hot_only_model_with_warm_targets(self, kind: str) -> None:
+    def test_hot_only_model_with_warm_targets_raise(self, kind: str) -> None:
         targets = self.warms[kind] + self.hots[kind]
-
-        # raise
         with pytest.raises(ValueError, match="doesn't support recommendations for warm"):
             self._get_reco(targets, "hot", "with_features", kind, on_unsupported_targets="raise")
 
-        # ignore
+    @pytest.mark.parametrize("kind", ("u2i", "i2i"))
+    def test_hot_only_model_with_warm_targets_ignore(self, kind: str) -> None:
+        targets = self.warms[kind] + self.hots[kind]
         actual = self._get_reco(targets, "hot", "with_features", kind, on_unsupported_targets="ignore")
         expected_targets = self.hots[kind]
         expected = self._get_reco(expected_targets, "hot", "with_features", kind)
         pd.testing.assert_frame_equal(actual, expected)
 
-        # warn
+    @pytest.mark.parametrize("kind", ("u2i", "i2i"))
+    def test_hot_only_model_with_warm_targets_warn(self, kind: str) -> None:
+        targets = self.warms[kind] + self.hots[kind]
         with warnings.catch_warnings(record=True) as w:
             self._get_reco(targets, "hot", "with_features", kind, on_unsupported_targets="warn")
             assert len(w) == 1

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,4 +1,4 @@
-#  Copyright 2022 MTS (Mobile Telesystems)
+# Copyright 2022-2024 MTS (Mobile Telesystems)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,4 +1,4 @@
-#  Copyright 2022-2024 MTS (Mobile Telesystems)
+#  Copyright 2022 MTS (Mobile Telesystems)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,23 +15,24 @@
 # pylint: disable=attribute-defined-outside-init
 
 import typing as tp
+import warnings
 
 import numpy as np
 import pandas as pd
 import pytest
-from pytest_mock import MockerFixture
 
 from rectools import Columns
 from rectools.dataset import Dataset
 from rectools.exceptions import NotFittedError
 from rectools.models.base import (
+    ErrorBehaviour,
     FixedColdRecoModelMixin,
     InternalRecoTriplet,
     ModelBase,
     Scores,
     SemiInternalRecoTriplet,
 )
-from rectools.types import AnyIds, ExternalIds, InternalIds
+from rectools.types import ExternalIds, InternalIds
 
 from .data import DATASET, INTERACTIONS
 
@@ -80,135 +81,6 @@ def test_raise_when_k_is_not_positive_i2i(k: int) -> None:
             dataset=DATASET,
             k=k,
         )
-
-
-class TestRecommendWithInternalIds:
-    def setup_method(self) -> None:
-        class SomeModel(ModelBase):
-            def _fit(self, dataset: Dataset, *args: tp.Any, **kwargs: tp.Any) -> None:
-                pass
-
-            def _recommend_u2i(
-                self,
-                user_ids: np.ndarray,
-                dataset: Dataset,
-                k: int,
-                filter_viewed: bool,
-                sorted_item_ids_to_recommend: tp.Optional[np.ndarray],
-            ) -> tp.Tuple[InternalIds, InternalIds, Scores]:
-                return [0, 0, 1], [0, 1, 2], [0.1, 0.2, 0.3]
-
-            def _recommend_i2i(
-                self,
-                target_ids: np.ndarray,
-                dataset: Dataset,
-                k: int,
-                sorted_item_ids_to_recommend: tp.Optional[np.ndarray],
-            ) -> tp.Tuple[InternalIds, InternalIds, Scores]:
-                return [0, 0, 1], [0, 1, 2], [0.1, 0.2, 0.3]
-
-        self.model = SomeModel().fit(DATASET)
-
-    def test_u2i_success(self, mocker: MockerFixture) -> None:
-        model = self.model
-        users = [0, 1]
-        items_to_recommend = [0, 1, 2]
-
-        spy = mocker.spy(model, "_recommend_u2i")
-        reco = model.recommend(
-            users=users,
-            dataset=DATASET,
-            k=2,
-            filter_viewed=False,
-            items_to_recommend=items_to_recommend,
-            assume_external_ids=False,
-            add_rank_col=False,
-        )
-
-        args, _ = spy.call_args  # args and kwargs properties are unavailable in Python < 3.8
-        assert list(args[0]) == users
-        assert list(args[4]) == items_to_recommend
-
-        excepted = pd.DataFrame(
-            {
-                Columns.User: [0, 0, 1],
-                Columns.Item: [0, 1, 2],
-                Columns.Score: [0.1, 0.2, 0.3],
-            }
-        )
-        pd.testing.assert_frame_equal(reco, excepted.astype({Columns.Score: np.float32}))
-
-    @pytest.mark.parametrize(
-        "users, items_to_recommend, error_type",
-        (
-            (["u1", "u2"], [0, 1], TypeError),
-            ([0, 1], ["i1", "i2"], TypeError),
-            (["u1", "u2"], ["i1", "i2"], TypeError),
-            ([0, 1], [-1, 1], ValueError),
-            ([-1, 1], [0, 1], ValueError),
-        ),
-    )
-    def test_u2i_with_incorrect_ids(self, users: AnyIds, items_to_recommend: AnyIds, error_type: tp.Type) -> None:
-        with pytest.raises(error_type):
-            self.model.recommend(
-                users=users,
-                dataset=DATASET,
-                k=2,
-                filter_viewed=False,
-                items_to_recommend=items_to_recommend,
-                assume_external_ids=False,
-            )
-
-    def test_i2i_success(self, mocker: MockerFixture) -> None:
-        model = self.model
-        target_items = [0, 1, 2]
-        items_to_recommend = [0, 1, 2]
-
-        spy = mocker.spy(model, "_recommend_i2i")
-        reco = model.recommend_to_items(
-            target_items=target_items,
-            dataset=DATASET,
-            k=2,
-            items_to_recommend=items_to_recommend,
-            assume_external_ids=False,
-            add_rank_col=False,
-            filter_itself=False,
-        )
-
-        args, _ = spy.call_args  # args and kwargs properties are unavailable in Python < 3.8
-        assert list(args[0]) == target_items
-        assert list(args[3]) == items_to_recommend
-
-        excepted = pd.DataFrame(
-            {
-                Columns.TargetItem: [0, 0, 1],
-                Columns.Item: [0, 1, 2],
-                Columns.Score: [0.1, 0.2, 0.3],
-            }
-        )
-        pd.testing.assert_frame_equal(reco, excepted.astype({Columns.Score: np.float32}))
-
-    @pytest.mark.parametrize(
-        "target_items, items_to_recommend, error_type",
-        (
-            (["i1", "i2"], [0, 1], TypeError),
-            ([0, 1], ["i1", "i2"], TypeError),
-            (["i1", "i2"], ["i1", "i2"], TypeError),
-            ([0, 1], [-1, 1], ValueError),
-            ([-1, 1], [0, 1], ValueError),
-        ),
-    )
-    def test_i2i_with_incorrect_ids(
-        self, target_items: AnyIds, items_to_recommend: AnyIds, error_type: tp.Type
-    ) -> None:
-        with pytest.raises(error_type):
-            self.model.recommend_to_items(
-                target_items=target_items,
-                dataset=DATASET,
-                k=2,
-                items_to_recommend=items_to_recommend,
-                assume_external_ids=False,
-            )
 
 
 class TestHotWarmCold:
@@ -331,7 +203,14 @@ class TestHotWarmCold:
         self.warms = {"u2i": [50], "i2i": [16]}
         self.colds = {"u2i": [60], "i2i": [18]}
 
-    def _get_reco(self, targets: ExternalIds, model_key: str, dataset_key: str, kind: str) -> pd.DataFrame:
+    def _get_reco(
+        self,
+        targets: ExternalIds,
+        model_key: str,
+        dataset_key: str,
+        kind: str,
+        on_unsupported_targets: ErrorBehaviour = "raise",
+    ) -> pd.DataFrame:
         model = self.models[model_key]
         if kind == "u2i":
             reco = model.recommend(
@@ -340,6 +219,7 @@ class TestHotWarmCold:
                 k=2,
                 filter_viewed=False,
                 add_rank_col=False,
+                on_unsupported_targets=on_unsupported_targets,
             )
             reco.rename(columns={Columns.User: "target"}, inplace=True)
         elif kind == "i2i":
@@ -349,6 +229,7 @@ class TestHotWarmCold:
                 k=2,
                 add_rank_col=False,
                 filter_itself=False,
+                on_unsupported_targets=on_unsupported_targets,
             )
             reco.rename(columns={Columns.TargetItem: "target"}, inplace=True)
         else:
@@ -461,16 +342,69 @@ class TestHotWarmCold:
     @pytest.mark.parametrize("dataset_key", ("no_features", "with_features"))
     @pytest.mark.parametrize("kind", ("u2i", "i2i"))
     @pytest.mark.parametrize("model_key", ("hot", "hot_warm"))
-    def test_not_cold_models_raise_on_cold(self, dataset_key: str, kind: str, model_key: str) -> None:
-        targets = self.colds[kind]
+    def test_not_cold_models_with_cold_targets(self, dataset_key: str, kind: str, model_key: str) -> None:
+        targets = self.colds[kind] + self.hots[kind]
+
+        # raise
         with pytest.raises(ValueError, match="doesn't support recommendations for cold"):
-            self._get_reco(targets, model_key, dataset_key, kind)
+            self._get_reco(targets, model_key, dataset_key, kind, on_unsupported_targets="raise")
+
+        # ignore
+        actual = self._get_reco(targets, model_key, dataset_key, kind, on_unsupported_targets="ignore")
+        expected_targets = self.hots[kind]
+        expected = self._get_reco(expected_targets, model_key, dataset_key, kind)
+        pd.testing.assert_frame_equal(actual, expected)
+
+        # warn
+        with warnings.catch_warnings(record=True) as w:
+            self._get_reco(targets, model_key, dataset_key, kind, on_unsupported_targets="warn")
+            assert len(w) == 1
+            for phrase in ("support", "cold"):
+                assert phrase in str(w[-1].message)
+            assert "warm" not in str(w[-1].message)
 
     @pytest.mark.parametrize("kind", ("u2i", "i2i"))
-    def test_warm_only_model_raises_on_warm_without_features(self, kind: str) -> None:
-        targets = self.warms[kind]
+    def test_warm_only_model_with_warm_targets_without_features(self, kind: str) -> None:
+        targets = self.warms[kind] + self.hots[kind]
+
+        # raise
         with pytest.raises(ValueError, match="doesn't support recommendations for cold"):
-            self._get_reco(targets, "hot_warm", "no_features", kind)
+            self._get_reco(targets, "hot_warm", "no_features", kind, on_unsupported_targets="raise")
+
+        # ignore
+        actual = self._get_reco(targets, "hot_warm", "no_features", kind, on_unsupported_targets="ignore")
+        expected_targets = self.hots[kind]
+        expected = self._get_reco(expected_targets, "hot_warm", "no_features", kind)
+        pd.testing.assert_frame_equal(actual, expected)
+
+        # warn
+        with warnings.catch_warnings(record=True) as w:
+            self._get_reco(targets, "hot_warm", "no_features", kind, on_unsupported_targets="warn")
+            assert len(w) == 1
+            for phrase in ("support", "cold"):
+                assert phrase in str(w[-1].message)
+            assert "warm" not in str(w[-1].message)
+
+    @pytest.mark.parametrize("kind", ("u2i", "i2i"))
+    def test_hot_only_model_with_warm_targets(self, kind: str) -> None:
+        targets = self.warms[kind] + self.hots[kind]
+
+        # raise
+        with pytest.raises(ValueError, match="doesn't support recommendations for warm"):
+            self._get_reco(targets, "hot", "with_features", kind, on_unsupported_targets="raise")
+
+        # ignore
+        actual = self._get_reco(targets, "hot", "with_features", kind, on_unsupported_targets="ignore")
+        expected_targets = self.hots[kind]
+        expected = self._get_reco(expected_targets, "hot", "with_features", kind)
+        pd.testing.assert_frame_equal(actual, expected)
+
+        # warn
+        with warnings.catch_warnings(record=True) as w:
+            self._get_reco(targets, "hot", "with_features", kind, on_unsupported_targets="warn")
+            assert len(w) == 1
+            for phrase in ("support", "cold", "warm"):
+                assert phrase in str(w[-1].message)
 
     @pytest.mark.parametrize("dataset_key", ("no_features", "with_features"))
     @pytest.mark.parametrize("kind", ("u2i", "i2i"))

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 MTS (Mobile Telesystems)
+#  Copyright 2022-2024 MTS (Mobile Telesystems)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Removed `assume_external_ids` parameter in `recommend` and `recommend_to_items` model methods 
- Added `on_unsupported_targets` in `recommend` and `recommend_to_items` model methods 
- Added `filter_on_interactions_df_row_indexes` method of `Dataset`
- Fixed `IntraListDiversity` metric computation in `cross_validate`