### PR TITLE
GPU support for ImplicitRanker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional `epochs` argument to `ImplicitALSWrapperModel.fit` method ([#203](https://github.com/MobileTeleSystems/RecTools/pull/203))
 - `save` and `load` methods to all of the models ([#206](https://github.com/MobileTeleSystems/RecTools/pull/206))
 - Model configs example ([#207](https://github.com/MobileTeleSystems/RecTools/pull/207))
+- `use_gpu` argument to `ImplicitRanker.rank` method ([#201](https://github.com/MobileTeleSystems/RecTools/pull/201))
 
 
 ## [0.8.0] - 28.08.2024


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/MobileTeleSystems/RecTools/blob/master/CONTRIBUTING.rst
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description

Implement use_gpu argument to ImplicitRanker.rank method. Adapt tests to it.

This PR closes #200  and #199 .

The GPU support works well but it does not pass all the test normally. The reason is behind implicit's implementation of topk on GPU and is not a bug: if predicted scores are equal, the order of elements is undefined. On CPU it is sorted in an ascending order but on GPU the order seems to be reverse. This *limitation* fails a lot of tests. Im not sure how to handle this because here are too much test cases to be rewritten without this thing.

Also I should mention changes in _get_neginf_score. On GPU the filtration score is slightly different than on CPU:  https://github.com/benfred/implicit/blob/main/implicit/gpu/knn.cu#L36 
I changed the implementation and its tests.

So, questions like interface for user, GPU by default, tests for ranker on GPU keep open and feedback from mainterers will be fine.

PS.
For testers: make sure implicit has GPU support on specific environment(`python -c "from implicit.gpu import HAS_CUDA; print(HAS_CUDA)"`). It is really unstable thing and I was able to run it normally only in the custom environment. On one created with `make install` it was falling back to disabled GPU.