### PR TITLE
if column.model not provided in visual app then set default model name

### DIFF
--- a/rectools/visuals/visual_app.py
+++ b/rectools/visuals/visual_app.py
@@ -29,6 +29,7 @@ TablesDict = tp.Dict[tp.Hashable, pd.DataFrame]
 MIN_WIDTH_LIMIT = 10
 REQUEST_NAMES_COL = "request_name"
 REQUEST_IDS_COL = "request_id"
+DEFAULT_MODEL_NAME = "model1"
 
 VisualAppT = tp.TypeVar("VisualAppT", bound="VisualAppBase")
 
@@ -71,7 +72,8 @@ class AppDataStorage:
         ----------
         reco : tp.Union[pd.DataFrame, TablesDict]
             Recommendations from different models in a form of a pd.DataFrame or a dict.
-            In DataFrame form model names must be specified in `Columns.Model` column. In dict form
+            In DataFrame form model names must be specified in `Columns.Model` column.
+            If not, `Columns.Model` column will be created with default value ``model1``. In dict form
             model names are supposed to be dict keys.
         item_data : pd.DataFrame
             Data for items that is used for visualisation in both interactions and recommendations
@@ -100,7 +102,7 @@ class AppDataStorage:
 
         if isinstance(reco, pd.DataFrame):
             if Columns.Model not in reco.columns:
-                raise KeyError("Missing `{Columns.Model}` column in `reco` DataFrame")
+                reco[Columns.Model] = DEFAULT_MODEL_NAME
             reco = cls._df_to_tables_dict(reco, Columns.Model)
         cls._check_columns_present_in_reco(reco=reco, id_col=id_col)
 

--- a/tests/visuals/test_visual_app.py
+++ b/tests/visuals/test_visual_app.py
@@ -51,7 +51,7 @@ ITEM_DATA = pd.DataFrame({Columns.Item: [3, 4, 5, 6, 7, 8], "feature_1": ["one",
 INTERACTIONS = pd.DataFrame({Columns.User: [1, 1, 2], Columns.Item: [3, 7, 8]})
 SELECTED_REQUESTS_U2I: tp.Dict[tp.Hashable, tp.Hashable] = {"user_one": 1, "user_three": 3}
 SELECTED_REQUESTS_I2I: tp.Dict[tp.Hashable, tp.Hashable] = {"item_three": 3}
-
+DEFAULT_MODEL_NAME = "model1"
 
 def check_data_storages_equal(one: AppDataStorage, two: AppDataStorage) -> None:
     assert one.id_col == two.id_col
@@ -229,17 +229,17 @@ class TestAppDataStorage:
             )
 
         # Missing `Columns.Model` in reco pd.DataFrame
-        with pytest.raises(KeyError):
-            incorrect_reco = pd.DataFrame(
-                {Columns.User: [1, 2, 3, 4], Columns.Item: [3, 4, 3, 4], Columns.Score: [0.99, 0.9, 0.5, 0.5]}
-            )
-            AppDataStorage.from_raw(
-                reco=incorrect_reco,
-                item_data=ITEM_DATA,
-                interactions=INTERACTIONS,
-                is_u2i=True,
-                selected_requests=SELECTED_REQUESTS_U2I,
-            )
+        incorrect_reco = pd.DataFrame(
+            {Columns.User: [1, 2, 3, 4], Columns.Item: [3, 4, 3, 4], Columns.Score: [0.99, 0.9, 0.5, 0.5]}
+        )
+        ads = AppDataStorage.from_raw(
+            reco=incorrect_reco,
+            item_data=ITEM_DATA,
+            interactions=INTERACTIONS,
+            is_u2i=True,
+            selected_requests=SELECTED_REQUESTS_U2I,
+        )
+        assert "model1" in ads.model_names
 
     def test_incorrect_interactions_for_reco_case(self) -> None:
 


### PR DESCRIPTION
## Description

Set default model name in `Column.Model` column, when using `VisualApp` [#118](https://github.com/MobileTeleSystems/RecTools/pull/118)

## Type of change

<!--
Please delete/mark options that are/aren't relevant
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Optimization

## How Has This Been Tested?
Before submitting a PR, please check yourself against the following list. It would save us quite a lot of time.
- Have you read the contribution guide?
- Have you updated the relevant docstrings? We're using Numpy format, please double-check yourself
- Does your change require any new tests?
- Have you updated the changelog file?

<!--
Should you feel your tests need an explanation or clarification, please put your description here. 
Otherwise feel free to remove this section.
-->
