### PR TITLE
Release/0.19.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ catboost_info/
 # Dev artifacts
 *.pt
 data/*
+
+# OpenCode
+opencode.json
+.opencode/

--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,3 @@ catboost_info/
 # Dev artifacts
 *.pt
 data/*
-
-# OpenCode
-opencode.json
-.opencode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [0.19.0] - 11.06.2026
 
 ### Added
 - `rectools.fast_transformers` module — standalone transformer-based sequential recommenders that work directly with torch tensors, bypassing the `Dataset`/pandas pipeline. GPU-native sequence building via `build_sequences()` gives ~30x preprocessing speedup over `SASRecDataPreparator` on ML-20M ([#306](https://github.com/MTSWebServices/RecTools/pull/306))

--- a/benchmark/compare_sasrec_unisrec.py
+++ b/benchmark/compare_sasrec_unisrec.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Compare RecTools SASRec vs UniSRec-ID on ML-20M.
 
 Both use full softmax, Adam, n_factors=256, 10 epochs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "RecTools"
-version = "0.19.0rc1"
+version = "0.19.0"
 description = "An easy-to-use Python library for building recommendation systems"
 license = "Apache-2.0"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "RecTools"
-version = "0.19.0"
+version = "0.19.0rc1"
 description = "An easy-to-use Python library for building recommendation systems"
 license = "Apache-2.0"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "RecTools"
-version = "0.18.0"
+version = "0.19.0"
 description = "An easy-to-use Python library for building recommendation systems"
 license = "Apache-2.0"
 authors = [

--- a/rectools/fast_transformers/__init__.py
+++ b/rectools/fast_transformers/__init__.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Fast Transformers: flat sequential recommenders without ItemNet hierarchy."""
 
 from .metrics import compute_metrics, hitrate_at_k, mrr_at_k, ndcg_at_k

--- a/rectools/fast_transformers/metrics.py
+++ b/rectools/fast_transformers/metrics.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """GPU-friendly ranking metrics for leave-one-out evaluation.
 
 All functions operate on PyTorch tensors and stay on the original device

--- a/rectools/fast_transformers/net.py
+++ b/rectools/fast_transformers/net.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Flat SASRec network: pre-norm transformer encoder with plain id embeddings."""
 
 import typing as tp

--- a/rectools/fast_transformers/preprocessing/__init__.py
+++ b/rectools/fast_transformers/preprocessing/__init__.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Vectorized sequence preprocessing for transformer recommenders."""
 
 from .sequence_data import SequenceBatchDataset, align_embeddings, build_sequences

--- a/rectools/fast_transformers/preprocessing/sequence_data.py
+++ b/rectools/fast_transformers/preprocessing/sequence_data.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Vectorized sequence building for transformer recommender training.
 
 All operations use pure PyTorch tensor ops, avoiding pandas/numpy overhead.

--- a/rectools/fast_transformers/unisrec/__init__.py
+++ b/rectools/fast_transformers/unisrec/__init__.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """UniSRec: sequential recommender with pretrained text embeddings."""
 
 from .lightning import UniSRecLightning

--- a/rectools/fast_transformers/unisrec/lightning.py
+++ b/rectools/fast_transformers/unisrec/lightning.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Lightning wrapper for UniSRec with configurable loss, optimizer, scheduler."""
 
 import math

--- a/rectools/fast_transformers/unisrec/model.py
+++ b/rectools/fast_transformers/unisrec/model.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """UniSRecModel: standalone sequential recommender with pretrained text embeddings."""
 
 import logging

--- a/rectools/fast_transformers/unisrec/net.py
+++ b/rectools/fast_transformers/unisrec/net.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """UniSRec network: SASRec encoder with pretrained text embeddings and learnable adaptor."""
 
 import typing as tp

--- a/rectools/version.py
+++ b/rectools/version.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-VERSION = "0.19.0"
+VERSION = "0.19.0rc1"

--- a/rectools/version.py
+++ b/rectools/version.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-VERSION = "0.18.0"
+VERSION = "0.19.0"

--- a/rectools/version.py
+++ b/rectools/version.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-VERSION = "0.19.0rc1"
+VERSION = "0.19.0"

--- a/tests/fast_transformers/__init__.py
+++ b/tests/fast_transformers/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/fast_transformers/test_metrics.py
+++ b/tests/fast_transformers/test_metrics.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Tests for GPU-friendly ranking metrics.
 
 Tests verify:

--- a/tests/fast_transformers/test_net.py
+++ b/tests/fast_transformers/test_net.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Tests for FlatSASRecNet network."""
 
 # pylint: disable=redefined-outer-name

--- a/tests/fast_transformers/test_onnx_export.py
+++ b/tests/fast_transformers/test_onnx_export.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Tests for ONNX export of UniSRecNet network and UniSRecModel.export_to_onnx."""
 
 # pylint: disable=redefined-outer-name,protected-access,import-outside-toplevel

--- a/tests/fast_transformers/test_sequence_data.py
+++ b/tests/fast_transformers/test_sequence_data.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Tests for vectorized sequence building and data utilities."""
 
 import torch

--- a/tests/fast_transformers/test_unisrec_lightning.py
+++ b/tests/fast_transformers/test_unisrec_lightning.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Tests for UniSRecLightning wrapper and _cosine_warmup_scheduler."""
 
 # pylint: disable=redefined-outer-name,protected-access

--- a/tests/fast_transformers/test_unisrec_model.py
+++ b/tests/fast_transformers/test_unisrec_model.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Tests for UniSRecModel (standalone, tensor-based API)."""
 
 import typing as tp

--- a/tests/fast_transformers/test_unisrec_net.py
+++ b/tests/fast_transformers/test_unisrec_net.py
@@ -1,3 +1,17 @@
+#  Copyright 2026 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 """Tests for UniSRecNet network."""
 
 # pylint: disable=redefined-outer-name


### PR DESCRIPTION
New lightweight module interface suited for training on largescale dataset with minimal overhead in terms of speed and memory consumption.

Added

- rectools.fast_transformers module — standalone transformer-based sequential recommenders that work directly with torch tensors, bypassing the Dataset/pandas pipeline. GPU-native sequence building via build_sequences() gives ~30x preprocessing speedup over SASRecDataPreparator on ML-20M (https://github.com/MTSWebServices/RecTools/pull/306)
- FlatSASRecNet network — flat SASRec implementation without the ItemNet hierarchy. Pre-norm transformer encoder with id-embeddings, causal masking, softmax and BCE losses (https://github.com/MTSWebServices/RecTools/pull/306)
- UniSRecNet network and UniSRecModel — sequential recommender with pretrained text embeddings (e.g. Qwen) and a learnable PCA/BN adaptor. Joint training of adaptor + transformer on pretrained embeddings. Configurable losses (softmax, BCE, gBCE, sampled_softmax), optimizers (Adam, AdamW), cosine warmup scheduler, early stopping, checkpoint save/load. UniSRecModel.fit() accepts raw (user_ids, item_ids, timestamps) tensors (https://github.com/MTSWebServices/RecTools/pull/306)
- SequenceBatchDataset — lightweight torch Dataset wrapper for sequence training data (https://github.com/MTSWebServices/RecTools/pull/306)